### PR TITLE
docs: complete AI disclosure statement with full team usage data

### DIFF
--- a/docs/sections/Appendix/subsections/aiDisclosureStatement.adoc
+++ b/docs/sections/Appendix/subsections/aiDisclosureStatement.adoc
@@ -1,3 +1,36 @@
 = Appendix
 
 == i. Generative AI Use Disclosure Statement
+
+=== Tools Used
+
+The team collected AI usage reports from all members through a shared GitHub Discussion. The following tools were reported:
+
+* *ChatGPT* — used by the majority of team members across research, documentation, and issue management tasks.
+* *Claude* — used by some members during the research phase for source discovery and formatting assistance.
+* *GitHub Copilot* — used for repository organization, issue management, and documentation drafting.
+* *Grammarly* — used by one member for grammar and readability review.
+
+=== How AI Was Used
+
+Team members reported three broad categories of use during this milestone.
+
+*Research support.* Several members used AI during the research phase to brainstorm directions, generate search keywords, identify candidate sources, and avoid redundancy across research tasks. In all cases, members read and verified the original materials independently. Sources suggested by AI were accepted only after manual confirmation that they were real, accessible, and relevant to the project scope. Some members noted that AI exposed them to sources and topics they would not have searched for on their own.
+
+*Documentation and writing.* AI was used to improve grammar, wording, and formatting consistency across issues and documentation sections. Some members used it to review whether their work met the milestone guidelines, or to organize ideas into a more structured form before writing. Members noted that AI did not handle complex cross-referencing well and that human review was necessary to catch inconsistencies.
+
+*Issue and task management.* AI was used to help identify duplicate issues, suggest missing topics not yet covered, and organize ideas before creating or refining issues. GitHub Copilot was specifically used to analyze the correlation between documentation sections and tracked issues to support traceability.
+
+=== Verification Practice
+
+Across all reported uses, team members applied their own judgment before accepting AI output. Candidate sources were verified by visiting the original materials. Documentation suggestions were reviewed against course guidelines and revised to match team conventions. Issue structures were adjusted to reflect the team's own understanding of the domain and requirements.
+
+Members reported that AI sometimes produced incorrect URLs, outdated references, or suggestions too general for the project's specific domain. Human review was necessary in all cases.
+
+=== What AI Was Not Used For
+
+AI tools did not define domain concepts, write requirements, or determine project scope. The domain model, requirements, user stories, personas, and function signatures in this document were produced through team discussion and course-guided analysis. No AI tool substituted for understanding the domain or making design decisions.
+
+=== Team Responsibility
+
+All content in this document was reviewed and approved before submission. AI tools served as a productivity aid. The design decisions, domain analysis, and requirement definitions reflect the team's own work.


### PR DESCRIPTION
## Summary
Completes the AI Disclosure Statement in the project appendix. The section was previously empty. It now documents the AI tools used by the team during this milestone, how they were used, what verification practices were applied, and what was not delegated to AI. This is required documentation for course compliance and transparency.

## Related Issue(s)
Closes #123 

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / Maintenance

## Changes Made
- Wrote the full AI Disclosure Statement based on usage reports collected from all team members via a shared GitHub Discussion
- Organized reported usage into three categories: research support, documentation and writing, and issue/task management
- Documented the four tools reported across the team: ChatGPT, Claude, GitHub Copilot, and Grammarly
- Added a verification practice section reflecting limitations members encountered (bad URLs, outdated references, weak cross-referencing)
- Clarified what AI was not used for, specifically domain modeling, requirements definition, and design decisions

## How to Test
1. Open `docs/project-doc.adoc` and render it with an AsciiDoc processor.
2. Navigate to the Appendix and verify the disclosure statement renders correctly under section "i. Generative AI Use Disclosure Statement."
3. Confirm the section covers: tools used, how AI was used, verification practices, what AI was not used for, and team responsibility.

## Acceptance Criteria
- [x] Lists all AI tools used by the team
- [x] Describes the stages and purposes for which AI was used
- [x] Describes the verification process applied to AI outputs
- [x] Clarifies what was not delegated to AI
- [x] Does not reference individual team members by name
- [x] Written in properly formatted AsciiDoc with no screenshots

## Risk & Impact
No known risks. Documentation-only change with no effect on source code or build artifacts.

## Screenshots / Evidence (if applicable)
N/A — documentation change. Rendered output can be verified locally via `asciidoctor`.

## Checklist
- [ X] PR is linked to an issue
- [ X] Code builds and runs locally
- [ X] No direct commits to `main`
- [ ] Requests review by 2 other team members