### PR TITLE
Create weekly Team Leader

### DIFF
--- a/.github/workflows/weekly-tl-issue.yml
+++ b/.github/workflows/weekly-tl-issue.yml
@@ -24,7 +24,9 @@ jobs:
         run: |
           gh issue create \
             --repo "${{ github.repository }}" \
-            --title "[Team Report] Weekly Team Progress — Week of ${{ steps.dates.outputs.monday }}" \
+            --title "[Team Report] Weekly Team Progress - Week of ${{ steps.dates.outputs.monday }}" \
+            --label "Issue in Progress,TL task,revised-by-manager" \
+            --assignee "Mannyrodd,jeracduran1,arianrodz21,ivxnmorxles,julivivas" \
             --body "$(cat <<'EOF'
 ## Objective
 
@@ -36,10 +38,11 @@ Each Team Leader is responsible for providing an update covering their team's co
 
 ## Acceptance Criteria
 
-- [ ] **Team Leader 1** has submitted their team's weekly update as a comment on this issue
-- [ ] **Team Leader 2** has submitted their team's weekly update as a comment on this issue
-- [ ] **Team Leader 3** has submitted their team's weekly update as a comment on this issue
-- [ ] **Team Leader 4** has submitted their team's weekly update as a comment on this issue
+- [ ] @Mannyrodd has submitted their team's weekly update as a comment on this issue
+- [ ] @jeracduran1 has submitted their team's weekly update as a comment on this issue
+- [ ] @arianrodz21 has submitted their team's weekly update as a comment on this issue
+- [ ] @ivxnmorxles has submitted their team's weekly update as a comment on this issue
+- [ ] @julivivas has submitted their team's weekly update as a comment on this issue
 - [ ] All updates include: tasks completed, tasks in progress, and any blockers
 
 ## Report Format


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically creates a GitHub issue every Thursday, prompting Team Leaders to submit their team's weekly progress report. The issue follows the project's standard issue template style and includes assignees and labels.

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Chore / Maintenance

## Changes Made

- Added `.github/workflows/weekly-tl-issue.yml` with a scheduled cron trigger every Thursday at 12:00 UTC
- Issue is auto-assigned to all 5 Team Leaders (@Mannyrodd, @jeracduran1, @arianrodz21, @ivxnmorxles, @julivivas)
- Issue is created with labels: `Issue in Progress`, `TL task`, `revised-by-manager`
- Issue body follows the standard template structure (Objective, Description, Acceptance Criteria, Expected Time Frame, Urgency, Difficulty)
- Workflow supports manual triggering via `workflow_dispatch`

## How to Test

1. Go to **Actions** tab in the repository
2. Select **Weekly Team Leaders Report Issue**
3. Click **Run workflow** to trigger it manually
4. Verify a new issue is created with the correct title, body, assignees, and labels

## Acceptance Criteria

- [x] A GitHub issue is created every Thursday automatically
- [x] All 5 Team Leaders are assigned to the issue
- [x] Issue follows the standard issue template style
- [x] Issue includes the correct labels
- [x] Workflow can be triggered manually for testing

## Risk & Impact

The three labels (`Issue in Progress`, `TL task`, `revised-by-manager`) must exist in the repository before the workflow runs, otherwise issue creation will fail. Create them under **Issues > Labels** if not already present.

## Checklist
- [x] Code builds and runs locally
- [x] No direct commits to `main`
- [x] Requests review by 2 other team members