### PR TITLE
Completed Figma Streak Display Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,61 +4,42 @@ import { StreakDisplay, StreakMilestoneBadge } from "./features/streaks";
 import type { WorkoutSession } from "./types";
 
 function StreakPreviewPage() {
-  const previewSessions: WorkoutSession[] = [];
-  const pastSession: WorkoutSession[] = [
-    { id: "1", userId: "demo", date: "2025-01-01", activityType: "gym", durationMinutes: 60 },
+  const activeSessions: WorkoutSession[] = [
+    { id: "1", userId: "demo", date: "2026-03-20", activityType: "gym", durationMinutes: 45 },
+    { id: "2", userId: "demo", date: "2026-03-21", activityType: "gym", durationMinutes: 50 },
+    { id: "3", userId: "demo", date: "2026-03-22", activityType: "gym", durationMinutes: 40 },
+    { id: "4", userId: "demo", date: "2026-03-23", activityType: "gym", durationMinutes: 55 },
+    { id: "5", userId: "demo", date: "2026-03-24", activityType: "gym", durationMinutes: 60 },
+    { id: "6", userId: "demo", date: "2026-03-25", activityType: "gym", durationMinutes: 35 },
+    { id: "7", userId: "demo", date: "2026-03-26", activityType: "gym", durationMinutes: 50 },
   ];
   const milestonePreview = [3, 7, 14, 30];
-  const missingSupabaseEnv =
-    !import.meta.env.VITE_SUPABASE_URL || !import.meta.env.VITE_SUPABASE_ANON_KEY;
 
   return (
-    <main
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        background: "linear-gradient(to bottom, #5f84e8, #0d2f8b)",
-        fontFamily: "Arial, sans-serif",
-      }}
-    >
-      <section
-        style={{
-          width: "100%",
-          maxWidth: 350,
-          padding: "30px 24px",
-          textAlign: "center",
-          color: "white",
-        }}
-      >
-        <h1
-          style={{
-            fontSize: 28,
-            marginTop: 0,
-            marginBottom: 18,
-            fontWeight: "bold",
-          }}
-        >
+    <main style={{
+      minHeight: "100vh",
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      background: "linear-gradient(to bottom, #5f84e8, #0d2f8b)",
+      fontFamily: "Arial, sans-serif",
+    }}>
+      <section style={{
+        width: "100%",
+        maxWidth: 500,
+        padding: "30px 24px",
+        textAlign: "center",
+        color: "white",
+      }}>
+        <h1 style={{ fontSize: 28, marginTop: 0, marginBottom: 18, fontWeight: "bold" }}>
           Streaks Preview
         </h1>
-        <p
-          style={{
-            marginTop: 0,
-            marginBottom: "1.25rem",
-            color: "#e2e8f0",
-            fontSize: 14,
-          }}
-        >
-          Temporary public route for review while login is unavailable.
-          {missingSupabaseEnv ? " Supabase is not configured yet." : ""}
-        </p>
 
-        <p style={{ fontSize: 13, color: "#cbd5e1", marginBottom: "0.5rem" }}>Empty state:</p>
-        <StreakDisplay sessions={previewSessions} />
+        <p style={{ fontSize: 13, color: "#cbd5e1", marginBottom: "0.5rem" }}>Active state:</p>
+        <StreakDisplay sessions={activeSessions} isBroken={false} longestStreak={67} />
 
         <p style={{ fontSize: 13, color: "#cbd5e1", margin: "1.5rem 0 0.5rem" }}>Broken state:</p>
-        <StreakDisplay sessions={pastSession} isBroken longestStreak={7} />
+        <StreakDisplay sessions={activeSessions} isBroken={true} longestStreak={67} />
 
         <p style={{ fontSize: 13, color: "#cbd5e1", margin: "1.5rem 0 0.5rem" }}>Milestone badges:</p>
         <div style={{ display: "grid", gap: "0.5rem" }}>

--- a/src/features/streaks/StreakDisplay.css
+++ b/src/features/streaks/StreakDisplay.css
@@ -1,11 +1,156 @@
-.streak-card {
+/* ==========================================================================
+   Streak Display — two-card layout (current + longest)
+   Matches Figma: Streaks Visualizer design
+   ========================================================================== */
+
+/* Wrapper ----------------------------------------------------------------- */
+.streak-display {
   width: 100%;
-  border-radius: 8px;
-  padding: 12px;
   text-align: center;
-  background: white;
-  color: #1b3ea8;
+  padding: 1.5rem 0;
 }
+
+.streak-display__header {
+  margin-bottom: 1.75rem;
+}
+
+.streak-display__title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 800;
+  color: white;
+  letter-spacing: -0.5px;
+}
+
+.streak-display__subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 14px;
+  color: white;
+}
+
+/* Two-column card grid ----------------------------------------------------- */
+.streak-display__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+@media (max-width: 360px) {
+  .streak-display__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Base card --------------------------------------------------------------- */
+.streak-card {
+  border-radius: 16px;
+  padding: 24px 16px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  border: 2px solid transparent;
+}
+
+.streak-card__label {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.streak-card__count {
+  margin: 0;
+  font-size: 52px;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -2px;
+}
+
+.streak-card__unit {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+/* Badge pill -------------------------------------------------------------- */
+.streak-card__badge {
+  display: inline-block;
+  margin-top: 8px;
+  padding: 5px 18px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+/* Active variant — teal/mint (Figma: top-left card) ----------------------- */
+.streak-card--active {
+  background-color: #b2ede0;
+  border-color: #7dd8c6;
+  color: #0d5c4a;
+}
+
+.streak-card--active .streak-card__label {
+  color: #0d8a6b;
+}
+
+.streak-card--active .streak-card__count {
+  color: #0a3d2e;
+}
+
+.streak-card__badge--active {
+  background-color: #2abf9c;
+  color: #033d2e;
+}
+
+/* Broken variant — pink/red (Figma: bottom-left card) --------------------- */
+.streak-card--broken {
+  background-color: #f5c6c6;
+  border-color: #f09090;
+  color: #7c1e1e;
+}
+
+.streak-card--broken .streak-card__label {
+  color: #b91c1c;
+}
+
+.streak-card--broken .streak-card__count {
+  color: #4a0f0f;
+}
+
+.streak-card__badge--broken {
+  background-color: #f08080;
+  color: #4a0f0f;
+}
+
+/* Longest variant — amber/yellow (Figma: right column) -------------------- */
+.streak-card--longest {
+  background-color: #fde68a;
+  border-color: #fbbf24;
+  color: #78350f;
+}
+
+.streak-card--longest .streak-card__label {
+  color: #b45309;
+}
+
+.streak-card--longest .streak-card__count {
+  color: #3b1a00;
+}
+
+.streak-card__badge--longest {
+  background-color: #f59e0b;
+  color: #3b1a00;
+}
+
+/* ==========================================================================
+   Legacy classes — kept for StreakBrokenState, StreakEmptyState,
+   and StreakMilestoneBadge 
+   ========================================================================== */
 
 .streak-empty-title {
   margin: 0;
@@ -31,7 +176,6 @@
   font-weight: 800;
 }
 
-/* Broken state */
 .streak-broken-card {
   width: 100%;
   border-radius: 8px;
@@ -61,7 +205,6 @@
   color: #9a3412;
 }
 
-/* Milestone badge */
 .streak-milestone-badge {
   width: 100%;
   border-radius: 10px;

--- a/src/features/streaks/StreakDisplay.tsx
+++ b/src/features/streaks/StreakDisplay.tsx
@@ -1,41 +1,120 @@
+import { motion } from "framer-motion";
 import type { WorkoutSession } from "../../types";
 import { computeStreak } from "../../lib/workouts";
 import StreakEmptyState, { type StreakEmptyStateProps } from "./StreakEmptyState";
 import StreakBrokenState, { type StreakBrokenStateProps } from "./StreakBrokenState";
 import "./StreakDisplay.css";
 
+// ---------------------------------------------------------------------------
+// 🔧 MOCK DATA — replace with real Supabase values when available
+// ---------------------------------------------------------------------------
+const MOCK_STREAK_DATA = {
+  currentStreak: 7,
+  longestStreak: 67,
+};
+// ---------------------------------------------------------------------------
+
 type StreakDisplayProps = {
   sessions: WorkoutSession[];
   isBroken?: boolean;
+  /** All-time longest streak. Hardcoded for now; wire to Supabase later. */
   longestStreak?: number;
   emptyStateProps?: StreakEmptyStateProps;
   brokenStateProps?: StreakBrokenStateProps;
 };
 
+// --- Individual streak card --------------------------------------------------
+
+type StreakCardProps = {
+  label: string;
+  days: number;
+  variant: "active" | "broken" | "longest";
+  badge: string;
+  delay?: number;
+};
+
+function StreakCard({ label, days, variant, badge, delay = 0 }: StreakCardProps) {
+  return (
+    <motion.section
+      aria-label={label}
+      className={`streak-card streak-card--${variant}`}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay, ease: "easeOut" }}
+    >
+      <p className="streak-card__label">{label}</p>
+      <p className="streak-card__count">
+        {days}
+        <span className="streak-card__unit"> day{days === 1 ? "" : "s"}</span>
+      </p>
+      <span className={`streak-card__badge streak-card__badge--${variant}`}>{badge}</span>
+    </motion.section>
+  );
+}
+
+// --- Main display -----------------------------------------------------------
+
 export default function StreakDisplay({
   sessions,
   isBroken,
-  longestStreak,
+  // TODO: replace MOCK_STREAK_DATA.longestStreak with real Supabase value
+  longestStreak = MOCK_STREAK_DATA.longestStreak,
   emptyStateProps,
   brokenStateProps,
 }: StreakDisplayProps) {
-  const streakCount = computeStreak(sessions);
+  // TODO: replace with real currentStreak from Supabase when available
+  const currentStreak = sessions.length > 0
+    ? computeStreak(sessions)
+    : MOCK_STREAK_DATA.currentStreak;
 
-  if (sessions.length === 0) {
+  const isStreakBroken = isBroken || currentStreak === 0;
+
+  if (sessions.length === 0 && !isBroken) {
     return <StreakEmptyState {...emptyStateProps} />;
   }
 
-  if (isBroken || streakCount === 0) {
-    return <StreakBrokenState longestStreak={longestStreak} {...brokenStateProps} />;
-  }
-
   return (
-    <section aria-label="Current workout streak" className="streak-card">
-      <p className="streak-label">Current streak</p>
-      <p className="streak-count">
-        {streakCount} day{streakCount === 1 ? "" : "s"}
-      </p>
-    </section>
+    <div className="streak-display">
+      <motion.div
+        className="streak-display__header"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.3 }}
+      >
+        <h2 className="streak-display__title">Your Streaks 🔥</h2>
+        <p className="streak-display__subtitle">Keep the momentum going!</p>
+      </motion.div>
+
+      <div className="streak-display__grid">
+        {/* Current streak */}
+        {isStreakBroken ? (
+          <StreakCard
+            label="Current"
+            days={0}
+            variant="broken"
+            badge="Broken"
+            delay={0.05}
+          />
+        ) : (
+          <StreakCard
+            label="Current"
+            days={currentStreak}
+            variant="active"
+            badge="Active"
+            delay={0.05}
+          />
+        )}
+
+        {/* Longest / all-time streak */}
+        <StreakCard
+          label="Longest"
+          days={longestStreak ?? 0}
+          variant="longest"
+          badge="All-time"
+          delay={0.15}
+        />
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
Replaces the existing streak UI with the new Figma-aligned implementation. The updated component introduces a two-card side-by-side layout showing both the current and longest streak, with clear visual distinction between active and broken states — replacing the previous single-card design. The component is self-contained and placed on the Home dashboard, but structured to be droppable into any page.

## Related Issue(s)
- Closes: #326 

## Type of Change
Select all that apply:
- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Chore / Maintenance

## Changes Made
- Updated `StreakDisplay.tsx` with a new two-card layout matching the Figma design
- Added internal `StreakCard` component with `variant: "active" | "broken" | "longest"` to handle all visual states
- Updated `StreakDisplay.css` with new card variants (teal for active, pink for broken, amber for longest)
- Preserved all legacy CSS classes so `StreakBrokenState`, `StreakEmptyState`, and `StreakMilestoneBadge` remain unaffected
- Hardcoded mock streak values with clearly marked `TODO` comments for Supabase wiring later

## How to Test
1. Pull this branch and run `npm run dev`
2. Open `http://localhost:5173/streaks-preview`
3. Confirm active state shows a teal card with current streak and an "Active" badge
4. Confirm broken state shows a pink card with 0 days and a "Broken" badge
5. Confirm the longest streak card is always amber/yellow regardless of active or broken state
6. Run `npm run build` and confirm the build succeeds with no errors

## Acceptance Criteria
Copy the relevant criteria from the issue and check them off:
- [ ] Two-card layout matches the approved Figma design
- [ ] Active state is visually distinct from broken state (color + badge)
- [ ] Longest streak card is always visible and unaffected by streak state
- [ ] Existing components (`StreakBrokenState`, `StreakEmptyState`, `StreakMilestoneBadge`) are not broken
- [ ] Mock data is clearly marked for future Supabase replacement

## Risk & Impact
Streak values are currently hardcoded as mock data (`currentStreak: 7`, `longestStreak: 67`). This is intentional and safe for now. Real values will be wired from Supabase in a follow-up issue. No existing streak logic or utility modules were modified.

## Checklist
- [x] PR is linked to an issue
- [x] Code builds and runs locally
- [x] No direct commits to `main`
- [ ] Requests review by 2 other team members
