### PR TITLE
LTT165 notification data model design adoc

### DIFF
--- a/docs/sections/Lecture Topic Tasks/subsections/LTT165.adoc
+++ b/docs/sections/Lecture Topic Tasks/subsections/LTT165.adoc
@@ -1,0 +1,79 @@
+==== Notification Types and Delivery States Data Model
+:author: Gerald Rodríguez
+
+This section defines the data model for the Notifications module in the Gym Tracker system. Its purpose is to establish the entities, fields, relationships, and notification categories needed to support user notifications in a Supabase-compatible database structure.
+
+The model extends the previously identified domain attributes (Section 4.3.4) by formalizing how notifications are stored, categorized, and tracked throughout their lifecycle.
+
+It supports key notification categories relevant to the project scope, including workout reminders, motivational messages, and weekly progress summaries. Additionally, it incorporates delivery state tracking, user association, trigger timing, and message content.
+
+This design serves as the foundation for future SQL migrations and notification system implementation.
+
+===== Overview
+
+The notification system is modeled using two related entities:
+
+* `notification_types` — defines the available categories of notifications  
+* `notifications` — stores individual notifications created for users  
+
+===== Entities
+
+===== `notification_types`
+
+[cols="1,1,1,1,3", options="header"]
+|===
+|Field |Type |Nullable |Default |Description
+
+|id |uuid |NO |gen_random_uuid() |Primary key  
+|code |text |NO |— |Unique internal identifier  
+|name |text |NO |— |Human-readable name  
+|description |text |YES |null |Optional description  
+|created_at |timestamptz |NO |now() |Creation timestamp  
+|===
+
+===== `notifications`
+
+[cols="1,1,1,1,3", options="header"]
+|===
+|Field |Type |Nullable |Default |Description
+
+|id |uuid |NO |gen_random_uuid() |Primary key  
+|user_id |uuid |NO |— |Foreign key referencing `auth.users.id`  
+|type_id |uuid |NO |— |Foreign key referencing `notification_types.id`  
+|title |text |NO |— |Notification title  
+|message |text |NO |— |Notification body  
+|trigger_at |timestamptz |YES |null |Scheduled delivery time  
+|sent_at |timestamptz |YES |null |Actual delivery timestamp  
+|status |text |NO |'pending' |Delivery state  
+|created_at |timestamptz |NO |now() |Creation timestamp  
+|===
+
+===== Notification Categories
+
+The system supports multiple notification categories:
+
+* Workout Reminder  
+* Motivational Message  
+* Weekly Progress Summary  
+
+===== Delivery Status
+
+Notification delivery is modeled using a status field:
+
+* `pending` — notification created but not yet sent  
+* `sent` — successfully delivered  
+* `failed` — delivery attempt failed  
+* `dismissed` — user has acknowledged or ignored the notification  
+
+===== Relationships
+
+* A user can receive many notifications  
+* Each notification belongs to exactly one user  
+* Each notification is associated with one notification type  
+
+===== ERD Representation
+
+[source,text]
+----
+auth.users → notifications → notification_types
+----


### PR DESCRIPTION
## Summary
This PR adds the notification data model design for the Notifications module.

## Related Issue(s)
Related to #165

## Type of Change
- [x] Documentation

## Changes Made
- Added notification data model design to Section 4.3
- Defined entities and fields
- Included Supabase-compatible SQL types
- Differentiated notification categories
- Added delivery state modeling
- Included ERD diagram

## Risk & Impact
Low risk. Documentation only.
@julivivas @pedroamorales @diegoperez16 