### PR TITLE
feat: add settings page with navigation (back button + gear icon)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useNavigate } from "react-router-dom";
 import { LoginPage, SignupPage, AuthProvider, ProtectedRoute, useAuth, signOut } from "./features/auth";
 import { StreakDisplay, StreakMilestoneBadge } from "./features/streaks";
+import SettingsPage from "./features/streaks/SettingsPage";
 import type { WorkoutSession } from "./types";
 
 function StreakPreviewPage() {
@@ -73,20 +74,62 @@ function StreakPreviewPage() {
 
 function HomePage() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const sessions: WorkoutSession[] = [];
-  
+
   return (
-    <main style={{ padding: "2rem", textAlign: "center" }}>
+    <main style={{ padding: "2rem", textAlign: "center", position: "relative" }}>
+      {/* Settings icon - top right */}
+      <button
+        onClick={() => navigate("/settings")}
+        aria-label="Settings"
+        style={{
+          position: "absolute",
+          top: "1.5rem",
+          right: "1.5rem",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          padding: "0.25rem",
+          borderRadius: "50%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="26"
+          height="26"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#374151"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
+      </button>
+
       <h1>Gym Tracker</h1>
       <p style={{ marginBottom: "2rem" }}>Logged in as: {user?.email}</p>
 
       <div style={{ maxWidth: 350, margin: "0 auto 2rem" }}>
         <StreakDisplay sessions={sessions} />
       </div>
-      
-      <button 
+
+      <button
         onClick={() => signOut()}
-        style={{ padding: "0.5rem 1rem", cursor: "pointer", background: "#ef4444", color: "white", border: "none", borderRadius: "4px" }}
+        style={{
+          padding: "0.5rem 1rem",
+          cursor: "pointer",
+          background: "#ef4444",
+          color: "white",
+          border: "none",
+          borderRadius: "4px",
+        }}
       >
         Logout
       </button>
@@ -110,6 +153,14 @@ function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/streaks-preview" element={<StreakPreviewPage />} />
+          <Route
+            path="/settings"
+            element={
+              <ProtectedRoute>
+                <SettingsPage />
+              </ProtectedRoute>
+            }
+          />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/src/features/streaks/SettingsPage.tsx
+++ b/src/features/streaks/SettingsPage.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "../auth";
+
+type WeightUnit = "kg" | "lb";
+type WeekStart = "mon" | "sun";
+
+export default function SettingsPage() {
+  const { user } = useAuth();
+  const [weightUnit, setWeightUnit] = useState<WeightUnit>("kg");
+  const [weekStart, setWeekStart] = useState<WeekStart>("mon");
+
+  return (
+    <main
+      style={{
+        background: "#e0f7f7",
+        minHeight: "100vh",
+        fontFamily: "Arial, sans-serif",
+        padding: "1rem",
+        display: "flex",
+        justifyContent: "center",
+      }}
+    >
+      <section
+        style={{
+          maxWidth: 450,
+          width: "100%",
+          background: "white",
+          borderRadius: "12px",
+          padding: "2rem",
+          boxShadow: "0 6px 16px rgba(0,0,0,0.1)",
+        }}
+      >
+        {/* Back Button */}
+        <Link
+          to="/"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.4rem",
+            marginBottom: "1rem",
+            color: "#0f4c4c",
+            textDecoration: "none",
+            fontWeight: "bold",
+            fontSize: "0.95rem",
+          }}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          Back
+        </Link>
+
+        <header
+          style={{
+            background: "#7DE1E1",
+            borderRadius: "10px",
+            padding: "1rem",
+            textAlign: "center",
+            fontWeight: "bold",
+            fontSize: "1.5rem",
+            marginBottom: "1.5rem",
+          }}
+        >
+          ⚡ Settings
+        </header>
+
+        {/* User Info */}
+        <div
+          style={{
+            marginBottom: "1.5rem",
+            padding: "1rem",
+            borderRadius: "8px",
+            background: "#f0fdfd",
+            boxShadow: "0 2px 6px rgba(0,0,0,0.05)",
+          }}
+        >
+          <h3 style={{ marginBottom: "0.5rem", color: "#0f4c4c" }}>Email</h3>
+          <p>{user?.email ?? "Unknown"}</p>
+
+          <h3 style={{ marginTop: "1rem", marginBottom: "0.5rem", color: "#0f4c4c" }}>Username</h3>
+          <p>{user?.user_metadata?.username ?? "Unknown"}</p>
+        </div>
+
+        {/* Weight Units */}
+        <div
+          style={{
+            marginBottom: "1.5rem",
+            padding: "1rem",
+            borderRadius: "8px",
+            background: "#f0fdf0",
+            boxShadow: "0 2px 6px rgba(0,0,0,0.05)",
+          }}
+        >
+          <h3 style={{ marginBottom: "0.5rem", color: "#0a4c0a" }}>Weight Units</h3>
+          <label style={{ marginRight: "1rem" }}>
+            <input
+              type="radio"
+              checked={weightUnit === "kg"}
+              onChange={() => setWeightUnit("kg")}
+            />{" "}
+            kg
+          </label>
+          <label>
+            <input
+              type="radio"
+              checked={weightUnit === "lb"}
+              onChange={() => setWeightUnit("lb")}
+            />{" "}
+            lb
+          </label>
+        </div>
+
+        {/* Week Start */}
+        <div
+          style={{
+            padding: "1rem",
+            borderRadius: "8px",
+            background: "#fff7f0",
+            boxShadow: "0 2px 6px rgba(0,0,0,0.05)",
+          }}
+        >
+          <h3 style={{ marginBottom: "0.5rem", color: "#4c2a0a" }}>Start of Week</h3>
+          <label style={{ marginRight: "1rem" }}>
+            <input
+              type="radio"
+              checked={weekStart === "mon"}
+              onChange={() => setWeekStart("mon")}
+            />{" "}
+            Monday
+          </label>
+          <label>
+            <input
+              type="radio"
+              checked={weekStart === "sun"}
+              onChange={() => setWeekStart("sun")}
+            />{" "}
+            Sunday
+          </label>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a Settings page and navigation to/from it. Users can access Settings via a gear icon on the Home page, configure preferences, and return home via a back button.

## Related Issue(s)
Closes #329 

## Type of Change
Select all that apply:
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / Maintenance

## Changes Made
- Built `SettingsPage` with user info (email, username), weight unit toggle (kg/lb), and week start toggle (Mon/Sun)
  - Username displays "Unknown" for now - not yet saved in Supabase user metadata
- Added a gear icon (⚙) in the top-right corner of `HomePage` linking to `/settings`
- Registered `/settings` as a protected route in `App.tsx`

## How to Test
1. Log in and land on the Home page
2. Click the gear icon (top-right) - should navigate to `/settings`
3. Verify your email is displayed correctly
4. Toggle weight unit between kg and lb
5. Toggle week start between Monday and Sunday
6. Click `← Back` - should return to `/`

## Acceptance Criteria
Copy the relevant criteria from the issue and check them off:
- [x] Settings page displays logged-in user's email.
- [x] User can toggle weight units (kg / lb)
- [x] User can toggle week start (Monday / Sunday)
- [x] Gear icon on Home navigates to Settings
- [x] Back button on Settings returns to Home

## Risk & Impact
No known risks.

## Screenshots / Evidence (if applicable)
Attach screenshots, logs, or other evidence to support the change.

## Checklist
- [x] PR is linked to an issue
- [x] Code builds and runs locally
- [x] No direct commits to `main`
- [ ] Requests review by 2 other team members
