### PR TITLE
Added Notification Risk Analysis

### DIFF
--- a/docs/sections/3 Analytic Part/subsections/3.1 concept analysis.adoc
+++ b/docs/sections/3 Analytic Part/subsections/3.1 concept analysis.adoc
@@ -349,3 +349,93 @@ All abstractions and concepts were derived from the rough sketch statements, and
 
 [.added]#The notification system domain consists of several key concepts, including notifications, users, notification triggers, workout events, and user preferences.
 Notifications are generated when specific triggers occur, such as workout creation or inactivity. These notifications are delivered to users based on their preferences, helping improve engagement and maintain workout consistency.#
+
+==== Concept Derivation: Missed or Failed Notifications Risk Analysis
+
+:author: AlejandroMB05
+
+== Overview
+
+The notification system in the gym tracker application is intended to help users maintain workout consistency and engagement by sending reminders, inactivity alerts, and workout-related updates. Because of this, missed or failed notifications present a significant risk to the effectiveness of the application.
+
+This analysis identifies possible causes of notification failures, the impact these failures may have on users, and considerations that may help reduce reliability issues in future development.
+
+== Possible Causes of Missed or Failed Notifications
+
+=== 1. Disabled Notification Permissions
+
+Users may deny or later disable notification permissions on their device. If permissions are disabled, the application will not be able to deliver notifications even if triggers occur successfully.
+
+*Potential Impact*
+
+* Users may miss workout reminders
+* Reduced workout consistency
+* Lower user engagement
+
+=== 2. Background Execution Restrictions
+
+Some devices restrict applications from running in the background to save battery life. This may prevent scheduled notifications from being triggered properly.
+
+*Potential Impact*
+
+* Delayed reminders
+* Missed inactivity alerts
+* Inconsistent notification behavior across devices
+
+=== 3. Incorrect Scheduling Logic
+
+Improper handling of timestamps, time zones, or scheduling conditions may cause notifications to trigger at the wrong time or not trigger at all.
+
+*Potential Impact*
+
+* Notifications appearing too early or too late
+* Duplicate reminders
+* Reduced user trust in the system
+
+=== 4. Application State Issues
+
+Notifications may fail if the application crashes, closes unexpectedly, or loses synchronization with stored workout data.
+
+*Potential Impact*
+
+* Workout reminders not generated
+* Missing progress-related notifications
+* Loss of user confidence
+
+=== 5. Device Connectivity Issues
+
+Some notifications may depend on synchronization or cloud-based scheduling. Poor internet connectivity could interfere with notification updates or scheduling consistency.
+
+*Potential Impact*
+
+* Delayed updates
+* Missed scheduled reminders
+* Incorrect notification timing
+
+== Recommendations
+
+=== 1. Permission Awareness
+
+The application should detect whether notification permissions are enabled and inform users when notifications are disabled.
+
+=== 2. Notification Validation
+
+The system should validate scheduled notifications to ensure reminders are not duplicated or triggered after workouts are completed.
+
+=== 3. Time Handling Consistency
+
+Notification scheduling should consistently handle timestamps and time zones to reduce timing-related issues.
+
+=== 4. Fallback Strategies
+
+The system should consider fallback mechanisms for missed reminders, such as rechecking notification conditions when the application is reopened.
+
+=== 5. User-Controlled Notification Settings
+
+Allowing users to configure reminders and notification behavior may reduce frustration caused by excessive or poorly timed notifications.
+
+== Summary
+
+Missed or failed notifications represent an important reliability risk for the gym tracker application. Notification failures can reduce user engagement, weaken workout consistency, and negatively affect the overall user experience.
+
+The main risks identified include disabled permissions, background execution restrictions, scheduling errors, application state issues, and connectivity problems. Addressing these concerns early in the design process will help create a more reliable and user-friendly notification system in future development.

--- a/docs/sections/Appendix/subsections/logBook.adoc
+++ b/docs/sections/Appendix/subsections/logBook.adoc
@@ -88,6 +88,8 @@
 
 | 3.1 Concept Analysis | AlejandroMB05 | Added | Added domain analysis for the notification system, including identification of core concepts such as Notification, User, Notification Trigger, Workout Event, and User Preferences.
 
+| 3.1 Concept Analysis | AlejandroMB05 | Added | Added a risk analysis document identifying possible causes of missed or failed notifications, their impact on user engagement and workout consistency, reliability concerns, and recommendations for improving notification reliability in the gym tracker application.
+
 | 3.1 Concept Analysis | Wilson A. Morales | Modified | Removed conflicting terms and aligned concept analysis with final terminology.
 
 | Section 4 (Domain Attributes)  | Hector Rivera | Added | Integrated Lecture Topic "Workout Data Validation and Integrity" into the Domain Attributes section. Refactored documentation structure according to guidelines (Discussions #221 and #277) and defined validation rules for key attributes such as weight, reps, and sets to ensure data integrity.


### PR DESCRIPTION
## Summary

This PR adds a risk analysis document for missed or failed notifications in the gym tracker application. The document identifies possible causes of notification failures, analyzes their impact on user engagement and workout consistency, and provides recommendations for improving notification reliability.

This is needed to better understand reliability risks associated with the future notification system before implementation begins.

## Related Issue(s)

Closes #423 

## Type of Change
Select all that apply:
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [X] Documentation
- [ ] Chore / Maintenance

## Changes Made

- Provide a concise list of the main changes.

- Added analysis of risks related to missed or failed notifications

- Identified possible causes such as disabled permissions, scheduling issues, and background restrictions

- Documented potential impacts on user engagement and workout tracking

- Added reliability concerns related to notification delivery and timing

- Included recommendations for reducing notification reliability issues

## How to Test

- Open the risk analysis documentation (AsciiDoc file)

- Review the identified risks and reliability concerns

- Verify that the analysis clearly explains possible causes and impacts of failed notifications

- Ensure recommendations are relevant and focused on domain-level analysis

## Acceptance Criteria
 
- [x] Possible causes of missed or failed notifications are identified

- [x] Impact on user engagement and workout tracking is analyzed

- [x] Reliability concerns related to scheduling and delivery timing are documented

- [x]  Recommendations for reducing notification delivery issues are included

- [x] Analysis remains focused on risk identification rather than implementation details

## Risk & Impact

No known risks

## Screenshots / Evidence (if applicable)

N/A

## Checklist
- [X] PR is linked to an issue
- [X] Code builds and runs locally
- [X] No direct commits to `main`
- [ ] Requests review by 2 other team members
