### PR TITLE
Improve message behavior in workout history

### DIFF
--- a/src/features/workouts/WorkoutHistoryPage.tsx
+++ b/src/features/workouts/WorkoutHistoryPage.tsx
@@ -153,6 +153,16 @@ const [typeFilter, setTypeFilter] = useState("all");
     loadWorkoutSessions();
   }, [user]);
 
+  useEffect(() => {
+    if (!actionMessage) return;
+
+    const timeout = setTimeout(() => {
+      setActionMessage(null);
+    }, 3000);
+
+    return () => clearTimeout(timeout);
+  }, [actionMessage]);
+
   function exitSelectMode() {
     setSelectMode(false);
     setSelectedIds(new Set());
@@ -193,7 +203,7 @@ const [typeFilter, setTypeFilter] = useState("all");
       await Promise.all(Array.from(selectedIds).map((id) => deleteWorkoutSession(id)));
       setSessions((prev) => prev.filter((s) => !selectedIds.has(s.workout_id)));
       exitSelectMode();
-      setActionMessage(`Deleted ${deletedCount} workout${deletedCount === 1 ? "" : "s"}.`);
+      setActionMessage(`Deleted ${deletedCount} workout${deletedCount === 1 ? "" : "s"}`);
       window.dispatchEvent(new Event("progress-updated"));
     } catch {
       setActionError("Some deletions failed. Please try again.");
@@ -262,7 +272,7 @@ const [typeFilter, setTypeFilter] = useState("all");
       );
       setEditingId(null);
       setEditDraft(null);
-      setActionMessage("Workout updated.");
+      setActionMessage("Workout updated");
       window.dispatchEvent(new Event("progress-updated"));
     } catch {
       setActionError("Failed to save changes. Please try again.");
@@ -326,41 +336,64 @@ const [typeFilter, setTypeFilter] = useState("all");
           </div>
         </header>
         {sessions.length > 0 && (
-          <div className="history-header-actions">
-            <button
-              className="history-select-btn"
-              onClick={() =>
-                setSortOrder((prev) =>
-                  prev === "newest" ? "oldest" : "newest"
-                )
-              }
-            >
-              {sortOrder === "newest"
-                ? "Newest first"
-                : "Oldest first"}
-            </button>
+          <div
+            className="history-filter-row"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: "1rem",
+            }}
+          >
+            <div className="history-header-actions">
+              <button
+                className="history-select-btn"
+                onClick={() =>
+                  setSortOrder((prev) =>
+                    prev === "newest" ? "oldest" : "newest"
+                  )
+                }
+              >
+                {sortOrder === "newest"
+                  ? "Newest first"
+                  : "Oldest first"}
+              </button>
 
-            <select
-              className="history-select-btn"
-              value={typeFilter}
-              onChange={(e) => setTypeFilter(e.target.value)}
-              style={{
-                appearance: "none",
-                WebkitAppearance: "none",
-                MozAppearance: "none",
-                textAlign: "center",
-                textAlignLast: "center",
-                
-              }}
-            >
-              <option value="all">All types</option>
+              <select
+                className="history-select-btn"
+                value={typeFilter}
+                onChange={(e) => setTypeFilter(e.target.value)}
+                style={{
+                  appearance: "none",
+                  WebkitAppearance: "none",
+                  MozAppearance: "none",
+                  textAlign: "center",
+                  textAlignLast: "center",
+                }}
+              >
+                <option value="all">All types</option>
 
-              {workoutTypes.map((type) => (
-                <option key={type} value={type}>
-                  {type}
-                </option>
-              ))}
-            </select>
+                {workoutTypes.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {actionMessage && (
+              <div
+                className="history-action-message"
+                style={{
+                  color: "var(--primary)",
+                  fontWeight: 600,
+                  fontSize: "0.85rem",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {actionMessage}
+              </div>
+            )}
           </div>
         )}
 
@@ -370,10 +403,6 @@ const [typeFilter, setTypeFilter] = useState("all");
 
         {sessionsError && (
           <div className="history-status-error">{sessionsError}</div>
-        )}
-
-        {actionMessage && (
-          <div className="history-status">{actionMessage}</div>
         )}
 
         {actionError && (


### PR DESCRIPTION
## Summary
This PR improves the placement and presentation of workout action feedback messages in the Workout History page. Action messages for updating and deleting workouts were moved to an inline position near the new sorting and filtering controls to provide more contextual and visually consistent feedback within the page layout.

## Related Issue(s)
Closes #442 

## Type of Change
Select all that apply:
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / Maintenance

## Changes Made

- Moved workout action feedback messages next to the filter/sorting controls section
- Updated feedback styling to reuse the existing application primary color and visual system
- Preserved automatic message dismissal behavior after 3 seconds
- Improved visual consistency by preventing overlap with the bottom navigation bar

## How to Test

- Run the application locally
- Navigate to the Workout History page
- Edit a workout session and save the changes
- Verify that a “Workout updated” message appears near the sorting/filter controls
- Enter select mode and delete one or more workout sessions
- Verify that a delete confirmation message appears in the same location
- Confirm that messages automatically disappear after 3 seconds
- Confirm that no page refresh is required for the messages to disappear

## Acceptance Criteria

- [x] Action messages appear after deleting a workout session.
- [x] Action messages appear after updating a workout session.
- [x] Messages are displayed inline near the sorting and filtering controls of the Workout History page.
- [x] Messages disappear automatically after 3 seconds.
- [x] Existing styling from the Workout History page is reused.
- [x] No page refresh is required for messages to disappear.

## Risk & Impact
No known risks

## Screenshots / Evidence (if applicable)

**Old message behavior**
<img width="1174" height="936" alt="MessageDisp" src="https://github.com/user-attachments/assets/d369269b-7f5f-4bf6-a91f-cdf883cdf5b8" />


**New message behavior**
<img width="857" height="938" alt="Screenshot 2026-05-18 at 2 56 52 PM" src="https://github.com/user-attachments/assets/37193d1e-2017-4452-8c64-e51e9e111cd8" />
<img width="857" height="938" alt="Screenshot 2026-05-18 at 2 57 35 PM" src="https://github.com/user-attachments/assets/1b9a8f36-6d7e-448f-abce-15b4b9258dd1" />


## Checklist
- [x] PR is linked to an issue
- [x] Code builds and runs locally
- [x] No direct commits to `main`
- [x] Requests review by 2 other team members
