### PR TITLE
docs: convert [.underline] notation to [.added]; add UML diagram to §3.2

### DIFF
--- a/docs/sections/2 Descriptive Part/subsections/2.1.5 events, actions, and behaviors.adoc
+++ b/docs/sections/2 Descriptive Part/subsections/2.1.5 events, actions, and behaviors.adoc
@@ -2,7 +2,7 @@
 
 ===== Domain Events
 
-[.underline]#The events listed here use the exact names and definitions established in Section 2.1.2. Each entry below is a reference to the corresponding concept in the terminology, not a separate definition. The purpose of this subsection is to show how these events appear in the context of the behaviors described below, not to restate or redefine them.#
+[.added]#The events listed here use the exact names and definitions established in Section 2.1.2. Each entry below is a reference to the corresponding concept in the terminology, not a separate definition. The purpose of this subsection is to show how these events appear in the context of the behaviors described below, not to restate or redefine them.#
 
 [.added]#The events listed here should align with those defined in Section 2.1.2. Where a name in this section differs from the terminology section, the terminology section definition takes precedence.#
 

--- a/docs/sections/2 Descriptive Part/subsections/2.1.6 function signatures.adoc
+++ b/docs/sections/2 Descriptive Part/subsections/2.1.6 function signatures.adoc
@@ -8,17 +8,17 @@ Where multiple outputs indicate updated state and produced results.
 
 ===== Core Recording Functions
 
-[.underline]#recordWorkout :#
-[.underline]#    WorkoutHistory >< Activity >< Duration >< CalendarDay >< Notes#
-[.underline]#    -> WorkoutHistory >< WorkoutSession#
+[.added]#recordWorkout :#
+[.added]#    WorkoutHistory >< Activity >< Duration >< CalendarDay >< Notes#
+[.added]#    -> WorkoutHistory >< WorkoutSession#
 
-[.underline]#Adds a completed Workout Session to the WorkoutHistory and returns the updated history together with the created session. Duration replaces the earlier type name Minutes throughout all signatures to align with the domain terminology in Section 2.1.2.#
+[.added]#Adds a completed Workout Session to the WorkoutHistory and returns the updated history together with the created session. Duration replaces the earlier type name Minutes throughout all signatures to align with the domain terminology in Section 2.1.2.#
 
-[.underline]#updateWorkoutSession :#
-[.underline]#    WorkoutHistory >< WorkoutSession >< Activity >< Duration >< CalendarDay >< Notes#
-[.underline]#    -> WorkoutHistory >< WorkoutSession#
+[.added]#updateWorkoutSession :#
+[.added]#    WorkoutHistory >< WorkoutSession >< Activity >< Duration >< CalendarDay >< Notes#
+[.added]#    -> WorkoutHistory >< WorkoutSession#
 
-[.underline]#Modifies an existing recorded Workout Session within the WorkoutHistory.#
+[.added]#Modifies an existing recorded Workout Session within the WorkoutHistory.#
 
 deleteWorkoutSession :
     WorkoutHistory >< WorkoutSession
@@ -89,7 +89,7 @@ compareSessions :
     WorkoutSession >< WorkoutSession
     -> SessionComparison
 
-Evaluates differences between two sessions, such as Duration or activity type. [.underline]#To obtain two sessions for comparison, the caller first invokes retrieveWorkoutHistory to obtain the GymGoer's WorkoutHistory, then invokes getSessionsInRange or getLastSessionByActivity to select the two sessions.#
+Evaluates differences between two sessions, such as Duration or activity type. [.added]#To obtain two sessions for comparison, the caller first invokes retrieveWorkoutHistory to obtain the GymGoer's WorkoutHistory, then invokes getSessionsInRange or getLastSessionByActivity to select the two sessions.#
 
 evaluateConsistency :
     WorkoutHistory >< TimePeriod
@@ -110,4 +110,4 @@ WorkoutSessions are obtained for a given GymGoer.#
 management functions, while GoalResult is the value returned by goal
 evaluation functions.#
 
-[.underline]#The type name Duration is used throughout all function signatures in place of the earlier Minutes. Duration is defined in Section 2.1.2 as the domain-level name for elapsed session time, expressed in minutes. The rename ensures that the function signature language matches the domain terminology rather than an implementation unit.#
+[.added]#The type name Duration is used throughout all function signatures in place of the earlier Minutes. Duration is defined in Section 2.1.2 as the domain-level name for elapsed session time, expressed in minutes. The rename ensures that the function signature language matches the domain terminology rather than an implementation unit.#

--- a/docs/sections/3 Analytic Part/subsections/3.2 validation and verification.adoc
+++ b/docs/sections/3 Analytic Part/subsections/3.2 validation and verification.adoc
@@ -501,3 +501,11 @@
 [.changed]#At this stage, the repository does not contain an automated workflow that runs `npm test`, `npm run test:acceptance`, or `npm run build` for application changes. The observed GitHub Actions workflows generate documentation PDFs and weekly project reports. They do not provide evidence of automated application verification on each update.#
 
 [.changed]#Several verification claims from the previous version of this section are not fully supported by the current tests. No observed test directly verifies persistence against a real database, weekly goal evaluation by active days, weekly comparison across multiple weeks, invalid-input rejection before persistence, or recalculation after editing past workout data. We therefore leave those checks in the planned or incomplete category for now.#
+
+==== [.added]#System Scope: UML Use Case Diagram#
+
+[.added]#The following use case diagram provides a system-scope overview of the GymTracker application. It shows all system operations available to the GymGoer and identifies three external service actors: Authentication Service, Data Storage Service, and Notification Service. The diagram complements the verification evidence above by making explicit which operations are in scope, which have acceptance test coverage, and which are still planned. Operations with current test evidence include Record Workout Session, View Workout History, and Log In. Operations without current automated test coverage — such as Compare Workout Sessions, Set Weekly Goal, Filter History by Activity/Exercise, and Send Reminder Notification — correspond to the planned or incomplete verification items noted in the section above.#
+
+[.added]#Figure 3.2.a — GymTracker UML Use Case Diagram.#
+
+image::sections/Lecture Topic Tasks/images/UML diagram.png[GymTracker UML Use Case Diagram, align="center", width=80%]

--- a/docs/sections/3 Analytic Part/subsections/3.3 inspection.adoc
+++ b/docs/sections/3 Analytic Part/subsections/3.3 inspection.adoc
@@ -1,219 +1,219 @@
-=== [.underline]#3.3 Requirements and Domain Model Inspection#
+=== [.added]#3.3 Requirements and Domain Model Inspection#
 
-[.underline]#This section documents a formal inspection of selected portions of the GymTracker domain model and requirements. The inspection uses both a defect-driven checklist (targeting known defect categories in requirements engineering) and a quality-driven checklist (targeting requirement quality attributes). The findings inform what was already corrected, what remains as a known gap, and what should be addressed in future iterations.#
+[.added]#This section documents a formal inspection of selected portions of the GymTracker domain model and requirements. The inspection uses both a defect-driven checklist (targeting known defect categories in requirements engineering) and a quality-driven checklist (targeting requirement quality attributes). The findings inform what was already corrected, what remains as a known gap, and what should be addressed in future iterations.#
 
-==== [.underline]#3.3.1 Inspection Overview#
+==== [.added]#3.3.1 Inspection Overview#
 
-[.underline]#*Type of inspection:* Checklist-based peer inspection.#
+[.added]#*Type of inspection:* Checklist-based peer inspection.#
 
-[.underline]#*Purpose:* To identify defects, ambiguities, inconsistencies, and quality gaps in the domain terminology (Section 2.1.2), domain requirements (Section 2.2.3), and interface requirements (Section 2.2.4) before final submission.#
+[.added]#*Purpose:* To identify defects, ambiguities, inconsistencies, and quality gaps in the domain terminology (Section 2.1.2), domain requirements (Section 2.2.3), and interface requirements (Section 2.2.4) before final submission.#
 
-[.underline]#*Items inspected:*#
+[.added]#*Items inspected:*#
 
 [cols="1,3", options="header"]
 |===
-|[.underline]#Item ID# |[.underline]#Description#
+|[.added]#Item ID# |[.added]#Description#
 
-|[.underline]#I-1#
-|[.underline]#Domain terminology section (Section 2.1.2) — 10 core domain concepts: Workout Session, Exercise, Attendance Day, Missed Day, Streak, Consistency, Goal, Time Frame, Week, Weekly Summary#
+|[.added]#I-1#
+|[.added]#Domain terminology section (Section 2.1.2) — 10 core domain concepts: Workout Session, Exercise, Attendance Day, Missed Day, Streak, Consistency, Goal, Time Frame, Week, Weekly Summary#
 
-|[.underline]#I-2#
-|[.underline]#Domain requirements (Section 2.2.3) — 8 requirements: Low-Effort Logging, Essential Information Recording, Persistent Storage and Retrieval, Streak Representation, Streak Calculation, Goal Evaluation, Weekly Aggregation, Editing and Correction of Workout Data#
+|[.added]#I-2#
+|[.added]#Domain requirements (Section 2.2.3) — 8 requirements: Low-Effort Logging, Essential Information Recording, Persistent Storage and Retrieval, Streak Representation, Streak Calculation, Goal Evaluation, Weekly Aggregation, Editing and Correction of Workout Data#
 
-|[.underline]#I-3#
-|[.underline]#Interface requirements (Section 2.2.4) — 5 requirements: User Initialization, Recording Real-World Workouts, Editing and Correction of Workout Data (interface side), Goal Initialization and Update, Viewing Progress and History#
+|[.added]#I-3#
+|[.added]#Interface requirements (Section 2.2.4) — 5 requirements: User Initialization, Recording Real-World Workouts, Editing and Correction of Workout Data (interface side), Goal Initialization and Update, Viewing Progress and History#
 |===
 
-[.underline]#*Inspectors:*#
+[.added]#*Inspectors:*#
 
 [cols="1,2,2", options="header"]
 |===
-|[.underline]#Inspector# |[.underline]#Role# |[.underline]#Items reviewed#
+|[.added]#Inspector# |[.added]#Role# |[.added]#Items reviewed#
 
-|[.underline]#Diego A. Perez Gandarillas (@diegoperez16)#
-|[.underline]#Project Manager / Reviewer#
-|[.underline]#I-2, I-3#
+|[.added]#Diego A. Perez Gandarillas (@diegoperez16)#
+|[.added]#Project Manager / Reviewer#
+|[.added]#I-2, I-3#
 
-|[.underline]#Julian Vivas (@julivivas)#
-|[.underline]#Documentation Team Leader#
-|[.underline]#I-1, I-2#
+|[.added]#Julian Vivas (@julivivas)#
+|[.added]#Documentation Team Leader#
+|[.added]#I-1, I-2#
 
-|[.underline]#Wilson A. Morales (@WilsonMorales8)#
-|[.underline]#Documentation Team Member#
-|[.underline]#I-1, I-3#
+|[.added]#Wilson A. Morales (@WilsonMorales8)#
+|[.added]#Documentation Team Member#
+|[.added]#I-1, I-3#
 
-|[.underline]#Alex M. Vazquez Galiano (@AlexitoUpr)#
-|[.underline]#Documentation Team Member#
-|[.underline]#I-2, I-3#
+|[.added]#Alex M. Vazquez Galiano (@AlexitoUpr)#
+|[.added]#Documentation Team Member#
+|[.added]#I-2, I-3#
 |===
 
-==== [.underline]#3.3.2 Defect-Driven Checklist#
+==== [.added]#3.3.2 Defect-Driven Checklist#
 
-[.underline]#The defect-driven checklist targets known defect categories in requirements and domain models. Each question is applied to every inspected item. A finding is recorded if a question exposes a defect.#
+[.added]#The defect-driven checklist targets known defect categories in requirements and domain models. Each question is applied to every inspected item. A finding is recorded if a question exposes a defect.#
 
 [cols="1,5,1", options="header"]
 |===
-|[.underline]#ID# |[.underline]#Question# |[.underline]#Scope#
+|[.added]#ID# |[.added]#Question# |[.added]#Scope#
 
-|[.underline]#DC-1#
-|[.underline]#Does the term or requirement use the word "user" in place of a domain-specific actor name (e.g., GymGoer)?#
-|[.underline]#I-1, I-2, I-3#
+|[.added]#DC-1#
+|[.added]#Does the term or requirement use the word "user" in place of a domain-specific actor name (e.g., GymGoer)?#
+|[.added]#I-1, I-2, I-3#
 
-|[.underline]#DC-2#
-|[.underline]#Does the requirement use vague qualifiers such as "quickly," "easily," "appropriate," or "sufficient" without a measurable definition?#
-|[.underline]#I-2, I-3#
+|[.added]#DC-2#
+|[.added]#Does the requirement use vague qualifiers such as "quickly," "easily," "appropriate," or "sufficient" without a measurable definition?#
+|[.added]#I-2, I-3#
 
-|[.underline]#DC-3#
-|[.underline]#Does a single requirement contain more than one obligation (i.e., uses "and" to join two distinct behavioral constraints that could be separated)?#
-|[.underline]#I-2, I-3#
+|[.added]#DC-3#
+|[.added]#Does a single requirement contain more than one obligation (i.e., uses "and" to join two distinct behavioral constraints that could be separated)?#
+|[.added]#I-2, I-3#
 
-|[.underline]#DC-4#
-|[.underline]#Is there a requirement that specifies implementation rather than observable behavior (e.g., names a specific data structure or programming pattern)?#
-|[.underline]#I-2, I-3#
+|[.added]#DC-4#
+|[.added]#Is there a requirement that specifies implementation rather than observable behavior (e.g., names a specific data structure or programming pattern)?#
+|[.added]#I-2, I-3#
 
-|[.underline]#DC-5#
-|[.underline]#Does a requirement reference a domain concept that is not defined in the domain terminology (Section 2.1.2)?#
-|[.underline]#I-2, I-3#
+|[.added]#DC-5#
+|[.added]#Does a requirement reference a domain concept that is not defined in the domain terminology (Section 2.1.2)?#
+|[.added]#I-2, I-3#
 
-|[.underline]#DC-6#
-|[.underline]#Is there an initial or boundary case that the requirement does not cover (e.g., first ever session, empty history, zero goal value)?#
-|[.underline]#I-2#
+|[.added]#DC-6#
+|[.added]#Is there an initial or boundary case that the requirement does not cover (e.g., first ever session, empty history, zero goal value)?#
+|[.added]#I-2#
 
-|[.underline]#DC-7#
-|[.underline]#Does a domain concept lack a stated definition, attributes, or relationship to other concepts?#
-|[.underline]#I-1#
+|[.added]#DC-7#
+|[.added]#Does a domain concept lack a stated definition, attributes, or relationship to other concepts?#
+|[.added]#I-1#
 
-|[.underline]#DC-8#
-|[.underline]#Does a requirement conflict with another requirement in the same section (i.e., they cannot both be satisfied simultaneously)?#
-|[.underline]#I-2, I-3#
+|[.added]#DC-8#
+|[.added]#Does a requirement conflict with another requirement in the same section (i.e., they cannot both be satisfied simultaneously)?#
+|[.added]#I-2, I-3#
 
-|[.underline]#DC-9#
-|[.underline]#Does a requirement specify behavior for a failure mode (network error, validation rejection, rollback failure) that the domain model does not mention as an event?#
-|[.underline]#I-2, I-3#
+|[.added]#DC-9#
+|[.added]#Does a requirement specify behavior for a failure mode (network error, validation rejection, rollback failure) that the domain model does not mention as an event?#
+|[.added]#I-2, I-3#
 
-|[.underline]#DC-10#
-|[.underline]#Is a time-dependent term (e.g., "timely," "recent," "current") used without a concrete time bound or reference to a defined Time Frame?#
-|[.underline]#I-2, I-3#
+|[.added]#DC-10#
+|[.added]#Is a time-dependent term (e.g., "timely," "recent," "current") used without a concrete time bound or reference to a defined Time Frame?#
+|[.added]#I-2, I-3#
 |===
 
-==== [.underline]#3.3.3 Quality-Driven Checklist#
+==== [.added]#3.3.3 Quality-Driven Checklist#
 
-[.underline]#The quality-driven checklist targets requirement quality attributes as defined in standard requirements engineering literature (completeness, consistency, traceability, verifiability, necessity, unambiguity, feasibility, atomicity, terminology alignment, prioritization).#
+[.added]#The quality-driven checklist targets requirement quality attributes as defined in standard requirements engineering literature (completeness, consistency, traceability, verifiability, necessity, unambiguity, feasibility, atomicity, terminology alignment, prioritization).#
 
 [cols="1,5,1", options="header"]
 |===
-|[.underline]#ID# |[.underline]#Question# |[.underline]#Scope#
+|[.added]#ID# |[.added]#Question# |[.added]#Scope#
 
-|[.underline]#QC-1#
-|[.underline]#Is the requirement complete? Does it specify all preconditions, the main success path, and at least one exception path?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-1#
+|[.added]#Is the requirement complete? Does it specify all preconditions, the main success path, and at least one exception path?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-2#
-|[.underline]#Is the requirement consistent with the domain model? Does it use only concepts defined in Section 2.1.2 or explicitly introduced?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-2#
+|[.added]#Is the requirement consistent with the domain model? Does it use only concepts defined in Section 2.1.2 or explicitly introduced?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-3#
-|[.underline]#Is the requirement traceable? Can it be linked to at least one stakeholder need (N*) and one project goal (G*) in the traceability matrix?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-3#
+|[.added]#Is the requirement traceable? Can it be linked to at least one stakeholder need (N*) and one project goal (G*) in the traceability matrix?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-4#
-|[.underline]#Is the requirement verifiable? Can it be confirmed as satisfied or violated by observing system output, running a test, or inspecting a record?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-4#
+|[.added]#Is the requirement verifiable? Can it be confirmed as satisfied or violated by observing system output, running a test, or inspecting a record?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-5#
-|[.underline]#Is the requirement necessary? Would removing it reduce the system's value to at least one identified stakeholder?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-5#
+|[.added]#Is the requirement necessary? Would removing it reduce the system's value to at least one identified stakeholder?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-6#
-|[.underline]#Is the requirement unambiguous? Is there only one valid interpretation of the stated behavior?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-6#
+|[.added]#Is the requirement unambiguous? Is there only one valid interpretation of the stated behavior?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-7#
-|[.underline]#Is the requirement feasible? Can it be implemented with the current React + Supabase tech stack within the remaining project timeline?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-7#
+|[.added]#Is the requirement feasible? Can it be implemented with the current React + Supabase tech stack within the remaining project timeline?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-8#
-|[.underline]#Is the requirement atomic? Does it describe exactly one observable behavior or system obligation?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-8#
+|[.added]#Is the requirement atomic? Does it describe exactly one observable behavior or system obligation?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-9#
-|[.underline]#Does the requirement use terminology from the domain vocabulary (Section 2.1.2) consistently? Does it avoid mixing domain terms with implementation jargon in the same statement?#
-|[.underline]#I-2, I-3#
+|[.added]#QC-9#
+|[.added]#Does the requirement use terminology from the domain vocabulary (Section 2.1.2) consistently? Does it avoid mixing domain terms with implementation jargon in the same statement?#
+|[.added]#I-2, I-3#
 
-|[.underline]#QC-10#
-|[.underline]#Is the requirement reflected in the AHP prioritization (Section 2.2.9)? If not, is there a documented reason for its exclusion from the prioritization?#
-|[.underline]#I-2#
+|[.added]#QC-10#
+|[.added]#Is the requirement reflected in the AHP prioritization (Section 2.2.9)? If not, is there a documented reason for its exclusion from the prioritization?#
+|[.added]#I-2#
 |===
 
-==== [.underline]#3.3.4 Inspection Findings#
+==== [.added]#3.3.4 Inspection Findings#
 
-[.underline]#Findings are classified by severity: High (blocks or misleads implementation), Medium (causes ambiguity or incomplete coverage), Low (style or traceability gap with minor impact).#
+[.added]#Findings are classified by severity: High (blocks or misleads implementation), Medium (causes ambiguity or incomplete coverage), Low (style or traceability gap with minor impact).#
 
 [cols="1,1,1,1,4,2", options="header"]
 |===
-|[.underline]#Finding ID# |[.underline]#Item# |[.underline]#Checklist# |[.underline]#Severity# |[.underline]#Description# |[.underline]#Disposition#
+|[.added]#Finding ID# |[.added]#Item# |[.added]#Checklist# |[.added]#Severity# |[.added]#Description# |[.added]#Disposition#
 
-|[.underline]#F-01#
-|[.underline]#I-2, I-3#
-|[.underline]#DC-1#
-|[.underline]#Medium#
-|[.underline]#Several requirements in Section 2.2.3 and 2.2.4 used the generic term "user" rather than the domain actor "GymGoer" in earlier milestone versions. Alejandro Lopez and Wilson Morales partially addressed this in Milestone 2. Residual instances remain in interface requirement narrative text.#
-|[.underline]#Partially resolved. Residual instances tracked for Milestone 3 cleanup.#
+|[.added]#F-01#
+|[.added]#I-2, I-3#
+|[.added]#DC-1#
+|[.added]#Medium#
+|[.added]#Several requirements in Section 2.2.3 and 2.2.4 used the generic term "user" rather than the domain actor "GymGoer" in earlier milestone versions. Alejandro Lopez and Wilson Morales partially addressed this in Milestone 2. Residual instances remain in interface requirement narrative text.#
+|[.added]#Partially resolved. Residual instances tracked for Milestone 3 cleanup.#
 
-|[.underline]#F-02#
-|[.underline]#I-2#
-|[.underline]#DC-6, QC-1#
-|[.underline]#High#
-|[.underline]#The "Streak Calculation" requirement does not specify the output when a GymGoer logs their very first Workout Session and there is no prior Streak to continue or break. This initial-state gap was independently identified in Section 2.2.8 (weak inconsistency WI-4). The requirement is incomplete for the first-session boundary case.#
-|[.underline]#Documented in 2.2.8. Implementation handles it by returning streak = 1, but the requirement text does not reflect this. Requirement needs update.#
+|[.added]#F-02#
+|[.added]#I-2#
+|[.added]#DC-6, QC-1#
+|[.added]#High#
+|[.added]#The "Streak Calculation" requirement does not specify the output when a GymGoer logs their very first Workout Session and there is no prior Streak to continue or break. This initial-state gap was independently identified in Section 2.2.8 (weak inconsistency WI-4). The requirement is incomplete for the first-session boundary case.#
+|[.added]#Documented in 2.2.8. Implementation handles it by returning streak = 1, but the requirement text does not reflect this. Requirement needs update.#
 
-|[.underline]#F-03#
-|[.underline]#I-3#
-|[.underline]#DC-2, QC-6#
-|[.underline]#Medium#
-|[.underline]#The notification and reminder interface requirements use the term "timely" when describing when reminders should be delivered, without binding "timely" to a defined Time Frame or concrete interval. This introduces ambiguity about whether "timely" means within the same day, within a configurable window, or before a specific event.#
-|[.underline]#Open. Notification team should add a concrete delivery window definition or reference the configurable preference in the Settings interface requirement.#
+|[.added]#F-03#
+|[.added]#I-3#
+|[.added]#DC-2, QC-6#
+|[.added]#Medium#
+|[.added]#The notification and reminder interface requirements use the term "timely" when describing when reminders should be delivered, without binding "timely" to a defined Time Frame or concrete interval. This introduces ambiguity about whether "timely" means within the same day, within a configurable window, or before a specific event.#
+|[.added]#Open. Notification team should add a concrete delivery window definition or reference the configurable preference in the Settings interface requirement.#
 
-|[.underline]#F-04#
-|[.underline]#I-2#
-|[.underline]#DC-10, QC-1#
-|[.underline]#Medium#
-|[.underline]#The "Goal Evaluation" requirement does not explicitly state whether a daily goal and a weekly goal are evaluated independently or whether meeting the daily goal contributes automatically toward the weekly target. The questionnaire AQ1-Q3 confirms stakeholders disagreed on this point. The elicitation case FE-2 resolves it as active days within a Week, but the requirement text itself does not state this resolution clearly.#
-|[.underline]#Partially resolved by FE-2. The requirement text should be updated to state explicitly that Goal Evaluation counts distinct Attendance Days within the Week, not raw session count.#
+|[.added]#F-04#
+|[.added]#I-2#
+|[.added]#DC-10, QC-1#
+|[.added]#Medium#
+|[.added]#The "Goal Evaluation" requirement does not explicitly state whether a daily goal and a weekly goal are evaluated independently or whether meeting the daily goal contributes automatically toward the weekly target. The questionnaire AQ1-Q3 confirms stakeholders disagreed on this point. The elicitation case FE-2 resolves it as active days within a Week, but the requirement text itself does not state this resolution clearly.#
+|[.added]#Partially resolved by FE-2. The requirement text should be updated to state explicitly that Goal Evaluation counts distinct Attendance Days within the Week, not raw session count.#
 
-|[.underline]#F-05#
-|[.underline]#I-1#
-|[.underline]#DC-7#
-|[.underline]#Low#
-|[.underline]#The term "Progress" appears in Section 2.1.2's consolidated vocabulary (Section 3.1.6) but does not have a standalone definition with stated attributes or relationships in the terminology section. It is used informally in several requirements. This gap means requirements referencing "Progress" cannot be fully evaluated for concept traceability.#
-|[.underline]#Open. Add a definition of Progress to Section 2.1.2 that links it to Workout History, Goal Evaluation, and Weekly Summary.#
+|[.added]#F-05#
+|[.added]#I-1#
+|[.added]#DC-7#
+|[.added]#Low#
+|[.added]#The term "Progress" appears in Section 2.1.2's consolidated vocabulary (Section 3.1.6) but does not have a standalone definition with stated attributes or relationships in the terminology section. It is used informally in several requirements. This gap means requirements referencing "Progress" cannot be fully evaluated for concept traceability.#
+|[.added]#Open. Add a definition of Progress to Section 2.1.2 that links it to Workout History, Goal Evaluation, and Weekly Summary.#
 
-|[.underline]#F-06#
-|[.underline]#I-2#
-|[.underline]#QC-3#
-|[.underline]#Low#
-|[.underline]#The "Separation of Nutrition Tracking" requirement in Section 2.2.3 does not appear in the traceability matrix in Section 4.4, and is not assigned a need ID. It is traceable informally to the domain boundary decision in Section 3.1.5 but does not have a formal N* link.#
-|[.underline]#Open. Add a traceability link or note that this requirement is a scope constraint rather than a stakeholder need, and document that distinction in Section 4.4.#
+|[.added]#F-06#
+|[.added]#I-2#
+|[.added]#QC-3#
+|[.added]#Low#
+|[.added]#The "Separation of Nutrition Tracking" requirement in Section 2.2.3 does not appear in the traceability matrix in Section 4.4, and is not assigned a need ID. It is traceable informally to the domain boundary decision in Section 3.1.5 but does not have a formal N* link.#
+|[.added]#Open. Add a traceability link or note that this requirement is a scope constraint rather than a stakeholder need, and document that distinction in Section 4.4.#
 
-|[.underline]#F-07#
-|[.underline]#I-3#
-|[.underline]#QC-4#
-|[.underline]#Medium#
-|[.underline]#The "Viewing Progress and History" interface requirement does not specify an observable success criterion for what constitutes a correctly displayed history. It states the system "shall provide means" but does not bound what must be visible, in what order, or within what time frame. This makes it difficult to write a deterministic acceptance test.#
-|[.underline]#Open. Acceptance test in `tests/acceptance/app.acceptance.test.tsx` partially covers it. The requirement text should add at minimum an ordering constraint (reverse chronological) and a completeness expectation (all sessions for the authenticated GymGoer).#
+|[.added]#F-07#
+|[.added]#I-3#
+|[.added]#QC-4#
+|[.added]#Medium#
+|[.added]#The "Viewing Progress and History" interface requirement does not specify an observable success criterion for what constitutes a correctly displayed history. It states the system "shall provide means" but does not bound what must be visible, in what order, or within what time frame. This makes it difficult to write a deterministic acceptance test.#
+|[.added]#Open. Acceptance test in `tests/acceptance/app.acceptance.test.tsx` partially covers it. The requirement text should add at minimum an ordering constraint (reverse chronological) and a completeness expectation (all sessions for the authenticated GymGoer).#
 
-|[.underline]#F-08#
-|[.underline]#I-2#
-|[.underline]#DC-3#
-|[.underline]#Low#
-|[.underline]#The "Persistent Storage and Retrieval" requirement combines two distinct obligations in a single statement: the system must persist Workout Sessions durably AND must make them retrievable by the owning GymGoer. These are separable and should be expressed as two atomic requirements (storage and retrieval) to support independent verification.#
-|[.underline]#Open. Low priority for course submission. Note for future requirement decomposition.#
+|[.added]#F-08#
+|[.added]#I-2#
+|[.added]#DC-3#
+|[.added]#Low#
+|[.added]#The "Persistent Storage and Retrieval" requirement combines two distinct obligations in a single statement: the system must persist Workout Sessions durably AND must make them retrievable by the owning GymGoer. These are separable and should be expressed as two atomic requirements (storage and retrieval) to support independent verification.#
+|[.added]#Open. Low priority for course submission. Note for future requirement decomposition.#
 |===
 
-==== [.underline]#3.3.5 Inspection Summary#
+==== [.added]#3.3.5 Inspection Summary#
 
-[.underline]#Eight findings were identified across the three inspected items. Two findings (F-02, F-07) are classified as high or medium severity and affect verifiability. F-02 documents a missing boundary case in Streak Calculation that was already partially handled in the implementation but is not reflected in the requirement text. F-07 documents a missing observable success criterion in the Viewing Progress and History interface requirement.#
+[.added]#Eight findings were identified across the three inspected items. Two findings (F-02, F-07) are classified as high or medium severity and affect verifiability. F-02 documents a missing boundary case in Streak Calculation that was already partially handled in the implementation but is not reflected in the requirement text. F-07 documents a missing observable success criterion in the Viewing Progress and History interface requirement.#
 
-[.underline]#Five findings (F-01, F-03, F-04, F-05, F-06) are medium or low severity and are either partially resolved through earlier milestone work or documented as open items. F-08 is a low-severity atomicity issue that does not block implementation but should be addressed in a later revision.#
+[.added]#Five findings (F-01, F-03, F-04, F-05, F-06) are medium or low severity and are either partially resolved through earlier milestone work or documented as open items. F-08 is a low-severity atomicity issue that does not block implementation but should be addressed in a later revision.#
 
-[.underline]#None of the inspected requirements were found to be infeasible (QC-7) or unnecessary (QC-5). All eight core domain requirements are traceable to at least one epic and one identified user need. The domain terminology is internally consistent after the revisions made in Milestone 2. The remaining gaps are localized and do not undermine the overall correctness of the domain model.#
+[.added]#None of the inspected requirements were found to be infeasible (QC-7) or unnecessary (QC-5). All eight core domain requirements are traceable to at least one epic and one identified user need. The domain terminology is internally consistent after the revisions made in Milestone 2. The remaining gaps are localized and do not undermine the overall correctness of the domain model.#

--- a/docs/sections/4 Specific Class Topics/subsections/4.4 traceability.adoc
+++ b/docs/sections/4 Specific Class Topics/subsections/4.4 traceability.adoc
@@ -78,246 +78,246 @@ We will label artifacts with short IDs and reference them inline:
 
 This scheme supports quick impact analysis when requirements evolve during later milestones.
 
-==== [.underline]#4.4.5 Traceability Policy#
+==== [.added]#4.4.5 Traceability Policy#
 
-[.underline]#This subsection defines the traceability policy for the GymTracker project: what should be traceable, what should not, at what level of granularity, what alternatives were considered, and why this approach was chosen.#
+[.added]#This subsection defines the traceability policy for the GymTracker project: what should be traceable, what should not, at what level of granularity, what alternatives were considered, and why this approach was chosen.#
 
-===== [.underline]#What should be traceable#
+===== [.added]#What should be traceable#
 
-[.underline]#The following artifact relationships are required to be traceable in this project:#
+[.added]#The following artifact relationships are required to be traceable in this project:#
 
-* [.underline]#Stakeholder needs (N*) to derived project goals (G*)#
-* [.underline]#Goals (G*) to epics (E*) and from epics to domain requirements (DR*), interface requirements (IR*), and machine requirements (MR*)#
-* [.underline]#Acquisition artifacts (AQ*) to the requirements they informed and the elicitation decisions (FE*, RT*) they produced#
-* [.underline]#Domain requirements and interface requirements to the implementation features that realize them (identified in Section 2.3)#
-* [.underline]#Requirements to the verification checks or acceptance tests that confirm them (V*, test file + test name)#
-* [.underline]#GitHub issues (GH-###) to the requirements they address, so task work remains linked to stakeholder value#
+* [.added]#Stakeholder needs (N*) to derived project goals (G*)#
+* [.added]#Goals (G*) to epics (E*) and from epics to domain requirements (DR*), interface requirements (IR*), and machine requirements (MR*)#
+* [.added]#Acquisition artifacts (AQ*) to the requirements they informed and the elicitation decisions (FE*, RT*) they produced#
+* [.added]#Domain requirements and interface requirements to the implementation features that realize them (identified in Section 2.3)#
+* [.added]#Requirements to the verification checks or acceptance tests that confirm them (V*, test file + test name)#
+* [.added]#GitHub issues (GH-###) to the requirements they address, so task work remains linked to stakeholder value#
 
-===== [.underline]#What should NOT be traced at this level#
+===== [.added]#What should NOT be traced at this level#
 
-[.underline]#The following are explicitly excluded from this traceability scheme to keep maintenance effort proportionate:#
+[.added]#The following are explicitly excluded from this traceability scheme to keep maintenance effort proportionate:#
 
-* [.underline]#Inline source code comments pointing to requirement IDs — rejected because they become stale on refactoring and create a false sense of completeness#
-* [.underline]#CSS and styling decisions — these are presentation choices that do not correspond to domain requirements or stakeholder needs#
-* [.underline]#Third-party library selection (Supabase, React, Vite) — implementation choices traceable to machine requirements at most, not to domain requirements or user stories#
-* [.underline]#Build configuration and CI pipeline details — infrastructure, not domain behavior#
-* [.underline]#Internal refactors where no behavior visible to a GymGoer changes#
+* [.added]#Inline source code comments pointing to requirement IDs — rejected because they become stale on refactoring and create a false sense of completeness#
+* [.added]#CSS and styling decisions — these are presentation choices that do not correspond to domain requirements or stakeholder needs#
+* [.added]#Third-party library selection (Supabase, React, Vite) — implementation choices traceable to machine requirements at most, not to domain requirements or user stories#
+* [.added]#Build configuration and CI pipeline details — infrastructure, not domain behavior#
+* [.added]#Internal refactors where no behavior visible to a GymGoer changes#
 
-===== [.underline]#Granularity#
+===== [.added]#Granularity#
 
-[.underline]#Traceability is maintained at the *requirement level*, not at the sub-clause level. A link from N2 to "Low-Effort Logging" is sufficient; the link does not need to reference individual bullet points within the requirement. For implementation, traceability is maintained at the *feature / component level* (e.g., `LogWorkoutModal.tsx` realizes "Recording Real-World Workouts"), not at the function or line level. For verification, traceability is maintained at the *test file and test name level*.#
+[.added]#Traceability is maintained at the *requirement level*, not at the sub-clause level. A link from N2 to "Low-Effort Logging" is sufficient; the link does not need to reference individual bullet points within the requirement. For implementation, traceability is maintained at the *feature / component level* (e.g., `LogWorkoutModal.tsx` realizes "Recording Real-World Workouts"), not at the function or line level. For verification, traceability is maintained at the *test file and test name level*.#
 
-===== [.underline]#Alternatives considered#
+===== [.added]#Alternatives considered#
 
 [cols="1,3,2", options="header"]
 |===
-|[.underline]#Alternative# |[.underline]#Description# |[.underline]#Reason for rejection#
+|[.added]#Alternative# |[.added]#Description# |[.added]#Reason for rejection#
 
-|[.underline]#Issue-only traceability#
-|[.underline]#Track only GitHub issue → requirement. No need-to-goal or requirement-to-test links.#
-|[.underline]#Too shallow. Does not support impact analysis when a stakeholder need changes, because the need-to-requirement path is missing.#
+|[.added]#Issue-only traceability#
+|[.added]#Track only GitHub issue → requirement. No need-to-goal or requirement-to-test links.#
+|[.added]#Too shallow. Does not support impact analysis when a stakeholder need changes, because the need-to-requirement path is missing.#
 
-|[.underline]#Fine-grained sub-requirement traceability#
-|[.underline]#Decompose each requirement into sub-clauses and trace each individually.#
-|[.underline]#Too high maintenance for a course project. Sub-clause IDs go stale on every requirement edit.#
+|[.added]#Fine-grained sub-requirement traceability#
+|[.added]#Decompose each requirement into sub-clauses and trace each individually.#
+|[.added]#Too high maintenance for a course project. Sub-clause IDs go stale on every requirement edit.#
 
-|[.underline]#Code-level traceability (inline comments)#
-|[.underline]#Embed requirement IDs in source code comments at the function level.#
-|[.underline]#Brittle. Silently breaks on refactoring. Creates a misleading audit trail.#
+|[.added]#Code-level traceability (inline comments)#
+|[.added]#Embed requirement IDs in source code comments at the function level.#
+|[.added]#Brittle. Silently breaks on refactoring. Creates a misleading audit trail.#
 
-|[.underline]#Tool-assisted traceability (dedicated traceability tool)#
-|[.underline]#Use a requirements management tool (e.g., JIRA, Doorstop) to maintain a live traceability graph.#
-|[.underline]#Not available within the course tooling. GitHub Issues approximate this at reduced fidelity.#
+|[.added]#Tool-assisted traceability (dedicated traceability tool)#
+|[.added]#Use a requirements management tool (e.g., JIRA, Doorstop) to maintain a live traceability graph.#
+|[.added]#Not available within the course tooling. GitHub Issues approximate this at reduced fidelity.#
 |===
 
-===== [.underline]#Why this approach was chosen#
+===== [.added]#Why this approach was chosen#
 
-[.underline]#Requirement-level traceability with stable IDs (N*, G*, E*, DR*, IR*, MR*) balances impact-analysis capability against maintenance cost. When a requirement changes, the ID stays the same and the links to needs, goals, and tests remain valid even if the text is rewritten. This is the minimum granularity needed to answer the core impact question: "if we change requirement X, what else must change?" The GitHub issue linkage adds a lightweight development workflow integration that does not require an external tool.#
+[.added]#Requirement-level traceability with stable IDs (N*, G*, E*, DR*, IR*, MR*) balances impact-analysis capability against maintenance cost. When a requirement changes, the ID stays the same and the links to needs, goals, and tests remain valid even if the text is rewritten. This is the minimum granularity needed to answer the core impact question: "if we change requirement X, what else must change?" The GitHub issue linkage adds a lightweight development workflow integration that does not require an external tool.#
 
-==== [.underline]#4.4.6 Extended Traceability Matrix#
+==== [.added]#4.4.6 Extended Traceability Matrix#
 
-[.underline]#This table extends the minimal matrix from Section 4.4.2 to include the fifth identified stakeholder need and to add implementation component and verification links for each requirement area.#
+[.added]#This table extends the minimal matrix from Section 4.4.2 to include the fifth identified stakeholder need and to add implementation component and verification links for each requirement area.#
 
 [cols="1,3,2,2,3,2", options="header"]
 |===
-|[.underline]#Need (N*)# |[.underline]#Need statement# |[.underline]#Goals (G*)# |[.underline]#Epics (E*)# |[.underline]#Key requirements (DR*/IR*)# |[.underline]#Verification evidence#
+|[.added]#Need (N*)# |[.added]#Need statement# |[.added]#Goals (G*)# |[.added]#Epics (E*)# |[.added]#Key requirements (DR*/IR*)# |[.added]#Verification evidence#
 
 |N1
 |Unified visibility of activity patterns over time
 |G2, G3
 |E1, E5
 |DR: Persistent Storage and Retrieval; IR: Viewing Progress and History
-|[.underline]#`tests/acceptance/app.acceptance.test.tsx` (history view test); `src/features/workouts/WorkoutHistoryPage.tsx`#
+|[.added]#`tests/acceptance/app.acceptance.test.tsx` (history view test); `src/features/workouts/WorkoutHistoryPage.tsx`#
 
 |N2
 |Low-effort structured workout logging
 |G4
 |E1
 |DR: Low-Effort Logging; IR: Recording Real-World Workouts
-|[.underline]#`tests/acceptance/app.acceptance.test.tsx` (log workout updates goal); `src/features/workouts/LogWorkoutModal.tsx`#
+|[.added]#`tests/acceptance/app.acceptance.test.tsx` (log workout updates goal); `src/features/workouts/LogWorkoutModal.tsx`#
 
 |N3
 |Measurable feedback for goal adherence and summaries
 |G2, G5
 |E3
 |DR: Goal Evaluation; DR: Performance Summary Representation; IR: Goal Initialization and Update
-|[.underline]#`src/lib/workouts.test.ts` (day counting, week bounds); `src/features/feedback/DailyGoalProgress.tsx`; `src/features/feedback/WeeklyProgressSummary.tsx`#
+|[.added]#`src/lib/workouts.test.ts` (day counting, week bounds); `src/features/feedback/DailyGoalProgress.tsx`; `src/features/feedback/WeeklyProgressSummary.tsx`#
 
 |N4
 |Reinforcement to support habit formation (streaks + feedback)
 |G1, G4
 |E2, E4
 |DR: Streak Representation; DR: Streak Calculation; IR: Automatic Streak Synchronization
-|[.underline]#`src/features/streaks/streakcalc.test.ts` (streak growth, grace period, reset); `src/features/streaks/StreakDisplay.tsx`#
+|[.added]#`src/features/streaks/streakcalc.test.ts` (streak growth, grace period, reset); `src/features/streaks/StreakDisplay.tsx`#
 
-|[.underline]#N5#
-|[.underline]#Clarity and simplicity for beginner and intermediate users#
-|[.underline]#G4, G5#
-|[.underline]#E1, E3, E5#
-|[.underline]#DR: Low-Effort Logging; IR: User Initialization; IR: Recording Real-World Workouts; MR: Interactive Response Time#
-|[.underline]#`tests/acceptance/auth-flow.acceptance.test.tsx` (login, signup flows); UI design system review#
+|[.added]#N5#
+|[.added]#Clarity and simplicity for beginner and intermediate users#
+|[.added]#G4, G5#
+|[.added]#E1, E3, E5#
+|[.added]#DR: Low-Effort Logging; IR: User Initialization; IR: Recording Real-World Workouts; MR: Interactive Response Time#
+|[.added]#`tests/acceptance/auth-flow.acceptance.test.tsx` (login, signup flows); UI design system review#
 |===
 
-==== [.underline]#4.4.7 Traceability Change Scenarios#
+==== [.added]#4.4.7 Traceability Change Scenarios#
 
-[.underline]#This section exploits the traceability graph to show the impact of three plausible change scenarios. For each scenario, the full chain of affected artifacts is traced from stakeholder needs through requirements, implementation components, tests, and documentation sections.#
+[.added]#This section exploits the traceability graph to show the impact of three plausible change scenarios. For each scenario, the full chain of affected artifacts is traced from stakeholder needs through requirements, implementation components, tests, and documentation sections.#
 
-===== [.underline]#Scenario 1: Streak grace period is removed#
+===== [.added]#Scenario 1: Streak grace period is removed#
 
-[.underline]#*Change description:* The product owner decides that streaks should count only strictly consecutive calendar days. The two-day grace period currently documented in Section 2.2.8 (WI-3) and implemented in `src/features/streaks/streakcalc.ts` is removed.#
+[.added]#*Change description:* The product owner decides that streaks should count only strictly consecutive calendar days. The two-day grace period currently documented in Section 2.2.8 (WI-3) and implemented in `src/features/streaks/streakcalc.ts` is removed.#
 
 [cols="1,4", options="header"]
 |===
-|[.underline]#Artifact# |[.underline]#Impact#
+|[.added]#Artifact# |[.added]#Impact#
 
-|[.underline]#N4 → G1 (Strengthen Habits)#
-|[.underline]#Goal rationale must be revisited. G1 justified the grace period as a habit-support mechanism. Removing it changes how the system reinforces consistency.#
+|[.added]#N4 → G1 (Strengthen Habits)#
+|[.added]#Goal rationale must be revisited. G1 justified the grace period as a habit-support mechanism. Removing it changes how the system reinforces consistency.#
 
-|[.underline]#DR: Streak Calculation#
-|[.underline]#Primary requirement change. The grace-period clause must be removed and the consecutive-day rule made strict.#
+|[.added]#DR: Streak Calculation#
+|[.added]#Primary requirement change. The grace-period clause must be removed and the consecutive-day rule made strict.#
 
-|[.underline]#DR: Streak Representation#
-|[.underline]#Secondary update required: the representation of GRACE state (shown in Section 2.1.5 state machine) must be removed.#
+|[.added]#DR: Streak Representation#
+|[.added]#Secondary update required: the representation of GRACE state (shown in Section 2.1.5 state machine) must be removed.#
 
-|[.underline]#Section 2.1.5 (State Machine Diagram)#
-|[.underline]#The GRACE state and its transitions must be removed from the state machine diagram.#
+|[.added]#Section 2.1.5 (State Machine Diagram)#
+|[.added]#The GRACE state and its transitions must be removed from the state machine diagram.#
 
-|[.underline]#Section 2.2.8 (Weak Inconsistencies, WI-3)#
-|[.underline]#The grace-period inconsistency entry becomes irrelevant and should be removed or marked resolved.#
+|[.added]#Section 2.2.8 (Weak Inconsistencies, WI-3)#
+|[.added]#The grace-period inconsistency entry becomes irrelevant and should be removed or marked resolved.#
 
-|[.underline]#`src/features/streaks/streakcalc.ts`#
-|[.underline]#Grace-period logic must be removed. The `EXPIRED` state and related conditions are affected.#
+|[.added]#`src/features/streaks/streakcalc.ts`#
+|[.added]#Grace-period logic must be removed. The `EXPIRED` state and related conditions are affected.#
 
-|[.underline]#`src/features/streaks/streakcalc.test.ts`#
-|[.underline]#Grace-period test cases (grace activation, grace-to-active recovery, grace expiration) would fail and must be removed or converted to strict-consecutive cases.#
+|[.added]#`src/features/streaks/streakcalc.test.ts`#
+|[.added]#Grace-period test cases (grace activation, grace-to-active recovery, grace expiration) would fail and must be removed or converted to strict-consecutive cases.#
 
-|[.underline]#`src/features/feedback/WeeklyProgressSummary.tsx`#
-|[.underline]#Calls `computeStreakFromSessions`. Behavior changes but no code change is required if the function interface is unchanged.#
+|[.added]#`src/features/feedback/WeeklyProgressSummary.tsx`#
+|[.added]#Calls `computeStreakFromSessions`. Behavior changes but no code change is required if the function interface is unchanged.#
 
-|[.underline]#Section 3.2 (Verification)#
-|[.underline]#Test result summary must be updated to reflect the new test set.#
+|[.added]#Section 3.2 (Verification)#
+|[.added]#Test result summary must be updated to reflect the new test set.#
 |===
 
-===== [.underline]#Scenario 2: Goal evaluation changes from active days to total session count#
+===== [.added]#Scenario 2: Goal evaluation changes from active days to total session count#
 
-[.underline]#*Change description:* The product owner decides that two sessions on the same calendar day should each count toward the weekly goal (total session count) rather than the active-day interpretation currently implemented.#
+[.added]#*Change description:* The product owner decides that two sessions on the same calendar day should each count toward the weekly goal (total session count) rather than the active-day interpretation currently implemented.#
 
 [cols="1,4", options="header"]
 |===
-|[.underline]#Artifact# |[.underline]#Impact#
+|[.added]#Artifact# |[.added]#Impact#
 
-|[.underline]#N3 → G2 (Encourage Reflection)#
-|[.underline]#The goal rationale changes: counting sessions favors high-frequency users over consistent-attendance users.#
+|[.added]#N3 → G2 (Encourage Reflection)#
+|[.added]#The goal rationale changes: counting sessions favors high-frequency users over consistent-attendance users.#
 
-|[.underline]#AQ1-Q3 (Acquisition evidence)#
-|[.underline]#The questionnaire asked stakeholders this exact question. The FE-2 elicitation resolution chose active days because stakeholders found day-counting more natural. This stakeholder evidence now conflicts with the proposed change; it should be revisited before implementing.#
+|[.added]#AQ1-Q3 (Acquisition evidence)#
+|[.added]#The questionnaire asked stakeholders this exact question. The FE-2 elicitation resolution chose active days because stakeholders found day-counting more natural. This stakeholder evidence now conflicts with the proposed change; it should be revisited before implementing.#
 
-|[.underline]#DR: Goal Evaluation#
-|[.underline]#Primary requirement change. The definition of "meeting a goal" must change from active Attendance Days to raw Workout Session count.#
+|[.added]#DR: Goal Evaluation#
+|[.added]#Primary requirement change. The definition of "meeting a goal" must change from active Attendance Days to raw Workout Session count.#
 
-|[.underline]#DR: Weekly Aggregation#
-|[.underline]#The aggregation function changes from `countWorkoutDaysInRange(...)` to `countWorkoutSessionsInRange(...)`.#
+|[.added]#DR: Weekly Aggregation#
+|[.added]#The aggregation function changes from `countWorkoutDaysInRange(...)` to `countWorkoutSessionsInRange(...)`.#
 
-|[.underline]#`src/lib/workouts.ts`#
-|[.underline]#`countWorkoutDaysInRange` function would need to be replaced or supplemented with a session-count variant.#
+|[.added]#`src/lib/workouts.ts`#
+|[.added]#`countWorkoutDaysInRange` function would need to be replaced or supplemented with a session-count variant.#
 
-|[.underline]#`src/features/feedback/WeeklyProgressSummary.tsx` and `DailyGoalProgress.tsx`#
-|[.underline]#Both components call the workouts utility. Both require logic updates.#
+|[.added]#`src/features/feedback/WeeklyProgressSummary.tsx` and `DailyGoalProgress.tsx`#
+|[.added]#Both components call the workouts utility. Both require logic updates.#
 
-|[.underline]#`src/lib/workouts.test.ts`#
-|[.underline]#Tests covering day-counting behavior would need revision. Same-day duplicate session tests would change expected outcomes.#
+|[.added]#`src/lib/workouts.test.ts`#
+|[.added]#Tests covering day-counting behavior would need revision. Same-day duplicate session tests would change expected outcomes.#
 
-|[.underline]#`tests/acceptance/app.acceptance.test.tsx`#
-|[.underline]#The acceptance test that verifies logging a workout updates the daily goal display may need to be updated if the count semantics change.#
+|[.added]#`tests/acceptance/app.acceptance.test.tsx`#
+|[.added]#The acceptance test that verifies logging a workout updates the daily goal display may need to be updated if the count semantics change.#
 
-|[.underline]#Section 3.2 (Verification), Section 2.3.1 (Implementation Fragments)#
-|[.underline]#Both sections reference `countWorkoutDaysInRange` by name. They must be updated to reflect the new function.#
+|[.added]#Section 3.2 (Verification), Section 2.3.1 (Implementation Fragments)#
+|[.added]#Both sections reference `countWorkoutDaysInRange` by name. They must be updated to reflect the new function.#
 |===
 
-===== [.underline]#Scenario 3: Email/password authentication replaced by Google-only sign-in#
+===== [.added]#Scenario 3: Email/password authentication replaced by Google-only sign-in#
 
-[.underline]#*Change description:* The team decides to remove email and password authentication entirely and require all users to authenticate through the Google OAuth IDP.#
+[.added]#*Change description:* The team decides to remove email and password authentication entirely and require all users to authenticate through the Google OAuth IDP.#
 
 [cols="1,4", options="header"]
 |===
-|[.underline]#Artifact# |[.underline]#Impact#
+|[.added]#Artifact# |[.added]#Impact#
 
-|[.underline]#IR: User Initialization#
-|[.underline]#Primary requirement change. The interface requirement for creating an account via email/password is no longer valid. It must be replaced with an OAuth-based user initialization requirement.#
+|[.added]#IR: User Initialization#
+|[.added]#Primary requirement change. The interface requirement for creating an account via email/password is no longer valid. It must be replaced with an OAuth-based user initialization requirement.#
 
-|[.underline]#IR: Login Flow (implicit, Section 2.2.4)#
-|[.underline]#The scenario and interface description for logging in with email/password must be replaced.#
+|[.added]#IR: Login Flow (implicit, Section 2.2.4)#
+|[.added]#The scenario and interface description for logging in with email/password must be replaced.#
 
-|[.underline]#N5 → G4 (Reduce Friction)#
-|[.underline]#Google sign-in could reduce friction for users with Google accounts, but creates a dependency on a third-party provider. The need rationale is partially preserved.#
+|[.added]#N5 → G4 (Reduce Friction)#
+|[.added]#Google sign-in could reduce friction for users with Google accounts, but creates a dependency on a third-party provider. The need rationale is partially preserved.#
 
-|[.underline]#MR: Authentication (Section 2.2.5)#
-|[.underline]#Machine requirements referencing password-based authentication must be updated.#
+|[.added]#MR: Authentication (Section 2.2.5)#
+|[.added]#Machine requirements referencing password-based authentication must be updated.#
 
-|[.underline]#`src/features/auth/api.ts`#
-|[.underline]#`signInWithEmail`, `signUpWithEmail`, `requestPasswordReset`, `updatePassword` are removed. `signInWithGoogle` becomes the sole auth path.#
+|[.added]#`src/features/auth/api.ts`#
+|[.added]#`signInWithEmail`, `signUpWithEmail`, `requestPasswordReset`, `updatePassword` are removed. `signInWithGoogle` becomes the sole auth path.#
 
-|[.underline]#`src/features/auth/LoginPage.tsx`, `SignupPage.tsx`, `ForgotPasswordPage.tsx`, `ResetPasswordPage.tsx`#
-|[.underline]#Three of these four pages are removed entirely. LoginPage is simplified to a single Google sign-in button.#
+|[.added]#`src/features/auth/LoginPage.tsx`, `SignupPage.tsx`, `ForgotPasswordPage.tsx`, `ResetPasswordPage.tsx`#
+|[.added]#Three of these four pages are removed entirely. LoginPage is simplified to a single Google sign-in button.#
 
-|[.underline]#`tests/acceptance/auth-flow.acceptance.test.tsx`#
-|[.underline]#All four email-based acceptance tests (login, signup, forgot-password, reset-password) break and must be replaced with OAuth flow tests.#
+|[.added]#`tests/acceptance/auth-flow.acceptance.test.tsx`#
+|[.added]#All four email-based acceptance tests (login, signup, forgot-password, reset-password) break and must be replaced with OAuth flow tests.#
 
-|[.underline]#`src/features/auth/AuthCallbackPage.tsx`#
-|[.underline]#This component becomes the primary post-auth landing page and its coverage becomes critical.#
+|[.added]#`src/features/auth/AuthCallbackPage.tsx`#
+|[.added]#This component becomes the primary post-auth landing page and its coverage becomes critical.#
 
-|[.underline]#Section 2.3.1 (Fragment 1: Protected routing and authentication flow)#
-|[.underline]#The code fragment showing `signInWithEmail` and `signUpWithEmail` becomes stale and must be replaced.#
+|[.added]#Section 2.3.1 (Fragment 1: Protected routing and authentication flow)#
+|[.added]#The code fragment showing `signInWithEmail` and `signUpWithEmail` becomes stale and must be replaced.#
 
-|[.underline]#Section 3.2 (Verification, auth test results)#
-|[.underline]#The observed test results for auth-flow acceptance tests would change.#
+|[.added]#Section 3.2 (Verification, auth test results)#
+|[.added]#The observed test results for auth-flow acceptance tests would change.#
 
-|[.underline]#Supabase Auth configuration (external)#
-|[.underline]#Google OAuth credentials must be configured in the Supabase dashboard. This is an external system change outside the codebase traceability scope.#
+|[.added]#Supabase Auth configuration (external)#
+|[.added]#Google OAuth credentials must be configured in the Supabase dashboard. This is an external system change outside the codebase traceability scope.#
 |===
 
-==== [.underline]#4.4.8 Effort Assessment for Traceability Maintenance#
+==== [.added]#4.4.8 Effort Assessment for Traceability Maintenance#
 
-[.underline]#This subsection assesses the effort required to maintain traceability information through each of the three change scenarios above, and draws a general conclusion about the cost-benefit relationship of the chosen traceability scheme.#
+[.added]#This subsection assesses the effort required to maintain traceability information through each of the three change scenarios above, and draws a general conclusion about the cost-benefit relationship of the chosen traceability scheme.#
 
 [cols="1,2,2,2", options="header"]
 |===
-|[.underline]#Scenario# |[.underline]#Implementation effort (estimated)# |[.underline]#Traceability maintenance effort (estimated)# |[.underline]#Key traceability value delivered#
+|[.added]#Scenario# |[.added]#Implementation effort (estimated)# |[.added]#Traceability maintenance effort (estimated)# |[.added]#Key traceability value delivered#
 
-|[.underline]#Scenario 1 (grace period removed)#
-|[.underline]#2–4 hours: modify `streakcalc.ts`, update test suite, verify build#
-|[.underline]#~1 hour: update DR text, remove WI-3, update state machine diagram, update Section 3.2 summary#
-|[.underline]#Prevented a stale weak inconsistency entry (WI-3) and a stale diagram from persisting after the change#
+|[.added]#Scenario 1 (grace period removed)#
+|[.added]#2–4 hours: modify `streakcalc.ts`, update test suite, verify build#
+|[.added]#~1 hour: update DR text, remove WI-3, update state machine diagram, update Section 3.2 summary#
+|[.added]#Prevented a stale weak inconsistency entry (WI-3) and a stale diagram from persisting after the change#
 
-|[.underline]#Scenario 2 (goal counting semantics)#
-|[.underline]#4–6 hours: modify `workouts.ts`, update two feedback components, update tests#
-|[.underline]#~2 hours: update DR text, revisit AQ1-Q3 evidence, update implementation fragment in 2.3.1, update Section 3.2#
-|[.underline]#Identified that AQ1-Q3 acquisition evidence conflicts with the proposed change — traceability surfaced a stakeholder alignment risk that would otherwise have been missed#
+|[.added]#Scenario 2 (goal counting semantics)#
+|[.added]#4–6 hours: modify `workouts.ts`, update two feedback components, update tests#
+|[.added]#~2 hours: update DR text, revisit AQ1-Q3 evidence, update implementation fragment in 2.3.1, update Section 3.2#
+|[.added]#Identified that AQ1-Q3 acquisition evidence conflicts with the proposed change — traceability surfaced a stakeholder alignment risk that would otherwise have been missed#
 
-|[.underline]#Scenario 3 (Google-only auth)#
-|[.underline]#6–10 hours: remove 3 pages, simplify LoginPage, update acceptance tests, configure Supabase#
-|[.underline]#~3 hours: update IR, MR, implementation fragment 1, Section 3.2 test results summary, and external Supabase note#
-|[.underline]#Prevented the acceptance test suite from being silently broken; traceability from IR → auth tests made the test update scope explicit#
+|[.added]#Scenario 3 (Google-only auth)#
+|[.added]#6–10 hours: remove 3 pages, simplify LoginPage, update acceptance tests, configure Supabase#
+|[.added]#~3 hours: update IR, MR, implementation fragment 1, Section 3.2 test results summary, and external Supabase note#
+|[.added]#Prevented the acceptance test suite from being silently broken; traceability from IR → auth tests made the test update scope explicit#
 |===
 
-[.underline]#*General conclusion:* Across all three scenarios, maintaining the traceability information added between 1 and 3 hours of documentation overhead per change, compared to an implementation effort of 2 to 10 hours. The overhead ratio is approximately 20–30% of implementation time. The primary value of the scheme was not in the matrix itself but in the structured question it forces: "which requirements, tests, and documentation sections reference the artifact being changed?" In two of the three scenarios (Scenario 2 and Scenario 3), traceability surfaced a non-obvious artifact that would likely have been missed without it: an acquisition evidence conflict in Scenario 2 and a stale implementation fragment in Scenario 3.#
+[.added]#*General conclusion:* Across all three scenarios, maintaining the traceability information added between 1 and 3 hours of documentation overhead per change, compared to an implementation effort of 2 to 10 hours. The overhead ratio is approximately 20–30% of implementation time. The primary value of the scheme was not in the matrix itself but in the structured question it forces: "which requirements, tests, and documentation sections reference the artifact being changed?" In two of the three scenarios (Scenario 2 and Scenario 3), traceability surfaced a non-obvious artifact that would likely have been missed without it: an acquisition evidence conflict in Scenario 2 and a stale implementation fragment in Scenario 3.#

--- a/docs/sections/Appendix/subsections/logBook.adoc
+++ b/docs/sections/Appendix/subsections/logBook.adoc
@@ -2,28 +2,28 @@
 
 [.changed]#This table records Milestone 2 additions, modifications, and removals at section level. Each listed change must also be marked in the corresponding document content with the added, changed, or removed role.#
 
-[.underline]#Milestone 3 additions and modifications are shown as underlined highlighted text in the document content. Each Milestone 3 entry below is also underlined.#
+[.added]#Milestone 3 additions and modifications are shown as underlined highlighted text in the document content. Each Milestone 3 entry below is also underlined.#
 
-==== [.underline]#Milestone 3 Changes#
+==== [.added]#Milestone 3 Changes#
 
 [width="100%", cols="4*", options="header", frame=all, grid=all, halign=center]
 
 |===
-| [.underline]#Section Name# | [.underline]#Member# | [.underline]#Added or Modified# | [.underline]#Description#
+| [.added]#Section Name# | [.added]#Member# | [.added]#Added or Modified# | [.added]#Description#
 
-| [.underline]#Legend (Introduction)# | [.underline]#Diego Perez# | [.underline]#Modified# | [.underline]#Added Milestone 3 change-visibility rule: M3 additions use underlined highlighted text `[.underline]#...#` to distinguish from M2's plain highlight `#...#`.#
+| [.added]#Legend (Introduction)# | [.added]#Diego Perez# | [.added]#Modified# | [.added]#Added Milestone 3 change-visibility rule: M3 additions use underlined highlighted text `[.added]#...#` to distinguish from M2's plain highlight `#...#`.#
 
-| [.underline]#2.1.5 Events, Actions, and Behaviors# | [.underline]#Diego Perez# | [.underline]#Added# | [.underline]#Added a state machine diagram (PlantUML) modeling the Streak lifecycle with four states (NO_STREAK, ACTIVE, GRACE, BROKEN), all transitions, and a state definition table. Placed in this section because the events defined here (Streak extended, Streak broken, etc.) map directly to the state transitions.#
+| [.added]#2.1.5 Events, Actions, and Behaviors# | [.added]#Diego Perez# | [.added]#Added# | [.added]#Added a state machine diagram (PlantUML) modeling the Streak lifecycle with four states (NO_STREAK, ACTIVE, GRACE, BROKEN), all transitions, and a state definition table. Placed in this section because the events defined here (Streak extended, Streak broken, etc.) map directly to the state transitions.#
 
-| [.underline]#2.2.1 User Stories, Epics, Features# | [.underline]#Diego Perez# | [.underline]#Added# | [.underline]#Added a use case diagram (PlantUML) showing the five epic areas as system operations, the GymGoer and Supabase Auth actors, and the extend/include relationships between use cases. Placed before the epics so the diagram provides a system-scope view that the individual user stories then decompose.#
+| [.added]#2.2.1 User Stories, Epics, Features# | [.added]#Diego Perez# | [.added]#Added# | [.added]#Added a use case diagram (PlantUML) showing the five epic areas as system operations, the GymGoer and Supabase Auth actors, and the extend/include relationships between use cases. Placed before the epics so the diagram provides a system-scope view that the individual user stories then decompose.#
 
-| [.underline]#2.2.4 Interface Requirements# | [.underline]#Diego Perez# | [.underline]#Added# | [.underline]#Added an event trace diagram (PlantUML sequence diagram) showing the full workout logging interaction between GymGoer, DailyGoalProgress, LogWorkoutModal, workoutSessionsApi, and Supabase. Includes the rollback note for the exercise persistence failure path. Placed before the requirement definitions to anchor the scenarios that follow.#
+| [.added]#2.2.4 Interface Requirements# | [.added]#Diego Perez# | [.added]#Added# | [.added]#Added an event trace diagram (PlantUML sequence diagram) showing the full workout logging interaction between GymGoer, DailyGoalProgress, LogWorkoutModal, workoutSessionsApi, and Supabase. Includes the rollback note for the exercise persistence failure path. Placed before the requirement definitions to anchor the scenarios that follow.#
 
-| [.underline]#3.3 Inspection (new section)# | [.underline]#Diego Perez# | [.underline]#Added# | [.underline]#Added a new Section 3.3 documenting a formal requirements and domain model inspection with named inspectors (Diego Perez, Julian Vivas, Wilson Morales, Alex Vazquez), a 10-item defect-driven checklist, a 10-item quality-driven checklist, three inspected items (terminology, domain requirements, interface requirements), and eight findings with severity ratings and dispositions.#
+| [.added]#3.3 Inspection (new section)# | [.added]#Diego Perez# | [.added]#Added# | [.added]#Added a new Section 3.3 documenting a formal requirements and domain model inspection with named inspectors (Diego Perez, Julian Vivas, Wilson Morales, Alex Vazquez), a 10-item defect-driven checklist, a 10-item quality-driven checklist, three inspected items (terminology, domain requirements, interface requirements), and eight findings with severity ratings and dispositions.#
 
-| [.underline]#4.4 Traceability# | [.underline]#Diego Perez# | [.underline]#Added# | [.underline]#Added Sections 4.4.5 through 4.4.8: traceability policy (what to trace, what not to, granularity, alternatives, rationale); extended traceability matrix adding N5 and implementation/verification links for all five needs; three change scenarios (grace period removal, goal counting semantics change, Google-only auth) fully traced across requirements, source files, tests, and documentation; and effort assessment comparing traceability maintenance overhead to implementation effort across the three scenarios.#
+| [.added]#4.4 Traceability# | [.added]#Diego Perez# | [.added]#Added# | [.added]#Added Sections 4.4.5 through 4.4.8: traceability policy (what to trace, what not to, granularity, alternatives, rationale); extended traceability matrix adding N5 and implementation/verification links for all five needs; three change scenarios (grace period removal, goal counting semantics change, Google-only auth) fully traced across requirements, source files, tests, and documentation; and effort assessment comparing traceability maintenance overhead to implementation effort across the three scenarios.#
 
-| [.underline]#Lecture Topic Tasks — LTT575# | [.underline]#Diego Perez# | [.underline]#Added# | [.underline]#Applied the four-step concept formation process (Schütz-Schmuck, 2024) to four raw domain description units about the GymGoer–WorkoutHistory–WorkoutSession relationship. Established that GymGoer is the aggregate root; revised `recordWorkout` to return `GymGoer >< WorkoutSession`; added `getSessionsInRange` and `getLastSessionByActivity` to close the retrieval gap exposed by DDU-D; rewrote the affected domain narrative fragment using only defined terminology. GH-575.#
+| [.added]#Lecture Topic Tasks — LTT575# | [.added]#Diego Perez# | [.added]#Added# | [.added]#Applied the four-step concept formation process (Schütz-Schmuck, 2024) to four raw domain description units about the GymGoer–WorkoutHistory–WorkoutSession relationship. Established that GymGoer is the aggregate root; revised `recordWorkout` to return `GymGoer >< WorkoutSession`; added `getSessionsInRange` and `getLastSessionByActivity` to close the retrieval gap exposed by DDU-D; rewrote the affected domain narrative fragment using only defined terminology. GH-575.#
 
 |===
 


### PR DESCRIPTION
## Summary

- Converts all 352 remaining `[.underline]#...#` markers to `[.added]#...#` to match the notation established by the Documentation branch across 5 files (3.3 inspection, 4.4 traceability, logBook, 2.1.5, 2.1.6)
- Adds Alex Vazquez's UML use case diagram to Section 3.2 (Validation and Verification), placed after the verification evidence as requested; includes a caption connecting the diagram to the test coverage status documented in the section

## Files changed

| File | Change |
|------|--------|
| `3.3 inspection.adoc` | 160 `[.underline]` → `[.added]` |
| `4.4 traceability.adoc` | 146 `[.underline]` → `[.added]` |
| `logBook.adoc` | 35 `[.underline]` → `[.added]` |
| `2.1.6 function signatures.adoc` | 10 `[.underline]` → `[.added]` |
| `2.1.5 events, actions, and behaviors.adoc` | 1 `[.underline]` → `[.added]` |
| `3.2 validation and verification.adoc` | UML use case diagram added at end |