### PR TITLE
docs: fix recordWorkout signature conflict, event name drift, duplicate heading

### DIFF
--- a/docs/sections/2 Descriptive Part/subsections/2.1.2 terminology.adoc
+++ b/docs/sections/2 Descriptive Part/subsections/2.1.2 terminology.adoc
@@ -138,14 +138,8 @@ Attendance Days, ending consecutiveness.
 An event in which the GymGoer’s activity for a Week has been summarized.
 
 
-[.added]#*recordWorkout(gymGoer: GymGoer, workout: Workout, date: CalendarDay, notes: WorkoutNotes) : GymGoer >< WorkoutSession* (Domain Concept, Category: Action)#
-[.added]#An action that creates a Workout Session for a GymGoer on a given Calendar Day and returns both the updated GymGoer (whose Workout History now contains the new session) and the newly created WorkoutSession. The GymGoer is included in the result because recording a workout modifies the GymGoer's Workout History — the WorkoutSession exists within that history and cannot be observed independently of it.#
-
-
-[.changed]#*recordWorkout(gymGoer: GymGoer, workout: Workout, date: CalendarDay, duration: Duration, notes: WorkoutNotes) : GymGoer* (Domain Concept, Category: Action)#
-An action that records a Workout Session for a GymGoer. The result is
-the updated GymGoer, whose Workout History now contains the new Workout
-Session.
+[.added]#*recordWorkout(gymGoer: GymGoer, workout: Workout, date: CalendarDay, duration: Duration, notes: WorkoutNotes) : GymGoer >< WorkoutSession* (Domain Concept, Category: Action)#
+[.added]#An action that records a Workout Session for a GymGoer on a given Calendar Day and returns both the updated GymGoer — whose Workout History now contains the new session — and the newly created WorkoutSession. Duration is required. WorkoutNotes are optional. The GymGoer is included in the result because recording a workout modifies the GymGoer's Workout History; the WorkoutSession exists within that history and is not accessible independently of it.#
 
 [.changed]#*retrieveWorkoutHistory(gymGoer: GymGoer) : WorkoutHistory* (Domain Concept, Category: Action)#
 An action that returns the Workout History associated with a given
@@ -158,6 +152,9 @@ occurred within a Time Frame.
 [.changed]#*findLastWorkoutSession(history: WorkoutHistory) : WorkoutSession* (Domain Concept, Category: Action)#
 An action that returns the most recent Workout Session in a Workout
 History.
+
+[.added]#*findSessionsByExercise(history: WorkoutHistory, exercise: Exercise) : List<WorkoutSession>* (Domain Concept, Category: Action)#
+[.added]#An action that returns all Workout Sessions in a WorkoutHistory that included a given Exercise. Used when a GymGoer wants to review past sessions that featured a specific exercise, such as bench press or treadmill.#
 
 [.changed]#*findSessionsByExercise(history: WorkoutHistory, exercise: Exercise) : List<WorkoutSession>* (Domain Concept, Category: Action)#
 An action that returns the Workout Sessions in which a specific Exercise

--- a/docs/sections/2 Descriptive Part/subsections/2.1.5 events, actions, and behaviors.adoc
+++ b/docs/sections/2 Descriptive Part/subsections/2.1.5 events, actions, and behaviors.adoc
@@ -2,30 +2,25 @@
 
 ===== Domain Events
 
-[.added]#The events listed here use the exact names and definitions established in Section 2.1.2. Each entry below is a reference to the corresponding concept in the terminology, not a separate definition. The purpose of this subsection is to show how these events appear in the context of the behaviors described below, not to restate or redefine them.#
+[.added]#The events listed here use the exact names defined in Section 2.1.2. Each entry is a reference to that concept — not a new or alternate definition. The purpose of listing them here is to show how the events appear in context with the actions and behaviors below.#
 
-[.added]#The events listed here should align with those defined in Section 2.1.2. Where a name in this section differs from the terminology section, the terminology section definition takes precedence.#
+[.added]#*Workout Session has just been performed* (→ Section 2.1.2)#
+[.added]#An event in which a Workout Session has occurred at a specific time on a specific Calendar Day.#
 
-*Workout session has just been completed*
-A person has finished performing one or more activities intended for fitness.
+[.added]#*Workout Session has just been skipped* (→ Section 2.1.2)#
+[.added]#An event in which an expected opportunity for workout activity has passed without a Workout Session occurring.#
 
-*Workout session has just been recorded*
-A completed workout has been added to the activity history.
+[.added]#*Goal period has just ended* (→ Section 2.1.2)#
+[.added]#An event in which the Time Frame associated with a Goal has completed.#
 
-*Workout day has just been missed*
-A day expected to include activity has passed without a workout session.
+[.added]#*Streak has just been extended* (→ Section 2.1.2)#
+[.added]#An event in which a Workout Session has occurred on the Calendar Day immediately following an Attendance Day, preserving consecutiveness.#
 
-*Streak has just been extended*
-A workout has occurred on a day immediately following another attendance day.
+[.added]#*Streak has just been broken* (→ Section 2.1.2)#
+[.added]#An event in which a Missed Day has occurred after one or more Attendance Days, ending consecutiveness.#
 
-*Streak has just been broken*
-A missed day has occurred following one or more consecutive attendance days.
-
-*Weekly goal period has just ended*
-The time interval associated with a weekly goal has completed.
-
-*Weekly activity summary has just been evaluated*
-The completed week’s activity has been compared against its goal.
+[.added]#*Weekly Summary has just been generated* (→ Section 2.1.2)#
+[.added]#An event in which the GymGoer’s activity for a Week has been summarized.#
 
 
 ===== Actions

--- a/docs/sections/2 Descriptive Part/subsections/2.1.6 function signatures.adoc
+++ b/docs/sections/2 Descriptive Part/subsections/2.1.6 function signatures.adoc
@@ -9,10 +9,10 @@ Where multiple outputs indicate updated state and produced results.
 ===== Core Recording Functions
 
 [.added]#recordWorkout :#
-[.added]#    WorkoutHistory >< Activity >< Duration >< CalendarDay >< Notes#
-[.added]#    -> WorkoutHistory >< WorkoutSession#
+[.added]#    GymGoer >< Workout >< CalendarDay >< Duration >< WorkoutNotes#
+[.added]#    -> GymGoer >< WorkoutSession#
 
-[.added]#Adds a completed Workout Session to the WorkoutHistory and returns the updated history together with the created session. Duration replaces the earlier type name Minutes throughout all signatures to align with the domain terminology in Section 2.1.2.#
+[.added]#Records a Workout Session for a GymGoer and returns the updated GymGoer together with the newly created WorkoutSession. The GymGoer is in the result because recording a workout modifies the GymGoer's WorkoutHistory; the WorkoutSession exists within that history and is not accessible independently. This signature is consistent with the definition in Section 2.1.2.#
 
 [.added]#updateWorkoutSession :#
 [.added]#    WorkoutHistory >< WorkoutSession >< Activity >< Duration >< CalendarDay >< Notes#

--- a/docs/sections/2 Descriptive Part/subsections/2.3 implementation.adoc
+++ b/docs/sections/2 Descriptive Part/subsections/2.3 implementation.adoc
@@ -1,5 +1,5 @@
 === 2.3 Implementation
-==== 2.3 Implementation Overview
+==== Overview
 
 ===== Scope
 


### PR DESCRIPTION
Addresses remaining professor feedback items: collapses 3 conflicting recordWorkout signatures into one canonical version, fixes event names in 2.1.5 to exactly match 2.1.2, adds findSessionsByExercise (used in narrative but undefined), fixes duplicate 2.3 heading.