### PR TITLE
Cover Label fix

### DIFF
--- a/docs/project-doc.adoc
+++ b/docs/project-doc.adoc
@@ -1,5 +1,5 @@
 = Gym Tracker
-Second Milestone - Software Requirements - INSO 4115
+Third Milestone - Software Requirements - INSO 4115
 Prof. Marko Schütz-Schmuck
 :doctype: book
 :toc:

--- a/docs/sections/Appendix/subsections/logBook.adoc
+++ b/docs/sections/Appendix/subsections/logBook.adoc
@@ -188,4 +188,6 @@
 
 | 4.3 Domain and Requirements Acquisition | Derek Velez | Added | Added a new section on domain and requirements acquisition about Domain Analysis through Competitive Analysis. It works for reference for our statements about Strava and MyFitnessPal
 
+| Presentation Page | Wilson A. Morales | Modified | Corrected the documentation cover milestone label to represent Milestone 3.
+
 |===


### PR DESCRIPTION
## Summary
Updates the cover/title block from "Second Milestone" to the Milestone 3 label so the document accurately identifies itself as the Milestone 3 submission. The body is already the M3 deliverable (M3 LogBook, M3 traceability matrix, and M3 change markers), so this corrects a front-matter inconsistency and satisfies the M3 guideline that the document reflect the current submission.

## Related Issue(s)
Closes #585

## Type of Change
Select all that apply:
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore / Maintenance

## Changes Made
- Changed the cover/title block subtitle from "Second Milestone - Software Requirements - INSO 4115" to the Milestone 3 label, marked with the editing theme.
- Added a corresponding Milestone 3 LogBook entry recording the affected section, the responsible member, and the change made.

## How to Test
- Open the rendered document and confirm the cover/title block reads the Milestone 3 label..

## Acceptance Criteria
- [x] Cover/title block updated from "Second Milestone" to the Milestone 3 label
- [x] A Milestone 3 LogBook entry is added identifying the affected section, the responsible member, and the change made
- [x] No other content in the document is altered

## Risk & Impact
No known risks.

## Screenshots / Evidence (if applicable)
<img width="435" height="237" alt="image" src="https://github.com/user-attachments/assets/8bc11d6a-9926-49b4-ab29-cdc2d4cb966d" />

## Checklist
- [x] PR is linked to an issue
- [x] Code builds and runs locally
- [x] No direct commits to `main`
- [x] Requests review by 2 other team members
